### PR TITLE
Changes in makeHistogram and makePdfMaps functions

### DIFF
--- a/RootInteractive/Tools/histoNDTools.py
+++ b/RootInteractive/Tools/histoNDTools.py
@@ -48,9 +48,6 @@ def makeHistogram(data, hisString, **kwargs):
     selection = description[0]
     histoInfo = description[1]
     del (varList[-1])
-    # get input data as an np array
-    df = data.query(selection)
-    inputArray = df[varList]
     histoInfo = histoInfo.replace('(', ',').replace(')', ',').split(",")
     bins = []
     hRange = []
@@ -62,9 +59,8 @@ def makeHistogram(data, hisString, **kwargs):
         logging.info("Variable list   :%s", varList)
         logging.info("Histogram bins  :%s", bins)
         logging.info("Histogram range :%s", hRange)
-    H, axis = np.histogramdd(inputArray.values, bins=bins, range=hRange)
-    histogram = {"H": H, "axes": axis, "name": histoInfo[0], "varNames": varList}
-    return histogram
+    H, axis = np.histogramdd(data.query(selection)[varList].values, bins=bins, range=hRange)
+    return {"H": H, "axes": axis, "name": histoInfo[0], "varNames": varList}
 
 
 def thnToNumpyDD(his):


### PR DESCRIPTION
Hello Marian, Marian, Martin and Alperen,
in this draft pull request I would like to show you the modifications I did to get this functionality to work for the space-charge calibration studies.

1) In the makeHistogram function, I tried to compactify the data frame usage to avoid as many copies as possible. This gets relevant when working with big data frames. If you have further ideas on how to optimize the code for memory usage or compress the objects, please let me know.

2) I applied a quick fix in the makePdfMaps function. It avoids errors when the bins to fit are empty, setting means, rms and meansOK flag to 0. Something similar is done for medians and quantiles when the last bin in the loop is reached. However, here probably some values different from 0 could be set but I did not look into the calculations yet.

Cheers,
Ernst