### PR TITLE
Python module request -> requests

### DIFF
--- a/RootInteractive/Tools/Histograms/__init__.py
+++ b/RootInteractive/Tools/Histograms/__init__.py
@@ -1,0 +1,6 @@
+try:
+    import ROOT
+    ROOT.gSystem.Load("$ALICE_ROOT/lib/libSTAT.so")
+
+except ImportError:
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ beakerx
 # ----------------------   jupyter notebook dependencies
 ipywidgets
 runtime
-request
+requests
 # ---------------------    machine learning dependencies
 sklearn
 #scikit-garden

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         # ----------------------   jupyter notebook dependencies
         'ipywidgets',
         'runtime',
-        'request',
+        'requests',
         # ---------------------    machine learning dependencies
         'sklearn',
         # 'scikit-garden',

--- a/virtualenv.md
+++ b/virtualenv.md
@@ -64,7 +64,7 @@ pip install scikit-garden
 pip install beakerx pandas ipywidgets
 pip install plot runtime
 pip install plotly
-pip install request
+pip install requests
 pip install bqplot
 pip install qgrid
 pip install ipympl


### PR DESCRIPTION
Module request is not available anymore:
```
Singularity> python3 -m pip install request
Defaulting to user installation because normal site-packages is not writeable
ERROR: Could not find a version that satisfies the requirement request (from versions: none)
ERROR: No matching distribution found for request

```
The git repo is also down: https://github.com/looking-for-a-job/request.py

Therefore, the RootInteractive installation fails.

Here I change the module to requests, which I hope does the same. 

Test which are done for the singularity containers pass:
```
pytest /lustre/alice/users/miranov/github/RootInteractive/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py 
pytest /lustre/alice/users/miranov/github/RootInteractive/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawArray.py
pytest /lustre/alice/users/miranov/github/RootInteractive/RootInteractive/Tools/test_aliTreePlayer.py 

```

If there are more test which need to pass, please let me know.

Cheers,
Ernst