### PR TITLE
PWGPP-581 N-dimensional histogramming benchmark

### DIFF
--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -157,8 +157,8 @@ ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy[3,:],label='Numpy
 ax4.legend()
 fig.show()
 
-output_string = "Benchmark results: \n"
-output_string = "Uniform binning: \n"
+output_string = "## Benchmark results: \n"
+output_string = "### Uniform binning: \n"
 output_string += "Numpy: \n"
 output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
 output_string += "\n\n"
@@ -194,7 +194,7 @@ if searchsorted_available:
     ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy_e[3,:],label='Numpy')
     ax4.legend()
     fig.show()
-    output_string = "Custom binning: \n"
+    output_string = "### Custom binning: \n"
     output_string += "Numpy: \n"
     output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"

--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -160,14 +160,14 @@ fig.show()
 output_string = "Benchmark results: \n"
 output_string += "Numpy: \n"
 output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-output_string += "\n"
+output_string += "\n\n"
 output_string += "PyTorch CPU: \n"
 output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-output_string += "\n"
+output_string += "\n\n"
 if torch.cuda.is_available():
     output_string += "PyTorch CUDA: \n"
     output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-    output_string += "\n"
+    output_string += "\n\n"
 
 if searchsorted_available:
     fig, ((ax1,ax2),(ax3,ax4)) = plt.subplots(2,2)
@@ -195,14 +195,14 @@ if searchsorted_available:
     fig.show()
     output_string += "Numpy: \n"
     output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-    output_string += "\n"
+    output_string += "\n\n"
     output_string += "PyTorch CPU: \n"
     output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-    output_string += "\n"
+    output_string += "\n\n"
     if torch.cuda.is_available():
         output_string += "PyTorch CUDA: \n"
         output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
-        output_string += "\n"
+        output_string += "\n\n"
 
 print(output_string)
 if create_output_file:

--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -8,6 +8,8 @@ Created on Sat Mar 14 16:32:34 2020
 import numpy as np
 import torch
 import timeit
+from tabulate import tabulate
+import io
 from matplotlib import pyplot as plt
 from histogramdd_pytorch import histogramdd
 
@@ -20,6 +22,8 @@ except ImportError:
 torch.random.manual_seed(19680801)
 torch.cuda.manual_seed_all(19680801)
 np.random.seed(19680801)
+
+create_output_file = True
 
 def get_tensors(n,d=3,device=None):
     x = torch.rand((d,n),device=device)
@@ -153,6 +157,18 @@ ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy[3,:],label='Numpy
 ax4.legend()
 fig.show()
 
+output_string = "Benchmark results: \n"
+output_string += "Numpy: \n"
+output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+output_string += "\n"
+output_string += "PyTorch CPU: \n"
+output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+output_string += "\n"
+if torch.cuda.is_available():
+    output_string += "PyTorch CUDA: \n"
+    output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += "\n"
+
 if searchsorted_available:
     fig, ((ax1,ax2),(ax3,ax4)) = plt.subplots(2,2)
     ax1.set_title("d=3")
@@ -177,3 +193,19 @@ if searchsorted_available:
     ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy_e[3,:],label='Numpy')
     ax4.legend()
     fig.show()
+    output_string += "Numpy: \n"
+    output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += "\n"
+    output_string += "PyTorch CPU: \n"
+    output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += "\n"
+    if torch.cuda.is_available():
+        output_string += "PyTorch CUDA: \n"
+        output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+        output_string += "\n"
+
+print(output_string)
+if create_output_file:
+    f = open("benchmark_histogramdd_pytorch.md","w")
+    f.write(output_string)
+    f.close()

--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -167,7 +167,7 @@ output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],sh
 output_string += "\n\n"
 if torch.cuda.is_available():
     output_string += "PyTorch CUDA: \n"
-    output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += tabulate(time_cuda*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"
 
 if searchsorted_available:
@@ -196,14 +196,14 @@ if searchsorted_available:
     fig.show()
     output_string = "### Custom binning: \n"
     output_string += "Numpy: \n"
-    output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += tabulate(time_numpy_e*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"
     output_string += "PyTorch CPU: \n"
-    output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+    output_string += tabulate(time_cpu_e*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"
     if torch.cuda.is_available():
         output_string += "PyTorch CUDA: \n"
-        output_string += tabulate(time_cpu*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
+        output_string += tabulate(time_cuda_e*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
         output_string += "\n\n"
 
 print(output_string)

--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -158,6 +158,7 @@ ax4.legend()
 fig.show()
 
 output_string = "Benchmark results: \n"
+output_string = "Uniform binning: \n"
 output_string += "Numpy: \n"
 output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
 output_string += "\n\n"
@@ -193,6 +194,7 @@ if searchsorted_available:
     ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy_e[3,:],label='Numpy')
     ax4.legend()
     fig.show()
+    output_string = "Custom binning: \n"
     output_string += "Numpy: \n"
     output_string += tabulate(time_numpy*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"

--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -194,7 +194,7 @@ if searchsorted_available:
     ax4.loglog([100,1000,10000,100000,1000000,10000000],time_numpy_e[3,:],label='Numpy')
     ax4.legend()
     fig.show()
-    output_string = "### Custom binning: \n"
+    output_string += "### Custom binning: \n"
     output_string += "Numpy: \n"
     output_string += tabulate(time_numpy_e*1000,["1e2","1e3","1e4","1e5","1e6","1e7"],showindex=[3,4,5,6],tablefmt="github")
     output_string += "\n\n"


### PR DESCRIPTION
This PR adds benchmarking code to the PyTorch N-dimensional histogramming tool. This is the file of the benchmark output on my machine. Times are in ms per one histogram.

### Uniform binning: 
Numpy: 
|    |     1e2 |     1e3 |     1e4 |     1e5 |     1e6 |     1e7 |
|----|---------|---------|---------|---------|---------|---------|
|  3 |  0.2095 |  0.3139 |  1.3679 | 11.4454 | 157.021 | 1960.69 |
|  4 |  0.3308 |  0.4531 |  1.8226 | 16.9595 | 219.219 | 2662.92 |
|  5 |  3.1293 |  3.2811 |  4.9445 | 24.8206 | 286.331 | 3574.78 |
|  6 | 34.408  | 34.6864 | 37.1484 | 61.7969 | 472.131 | 4551.02 |

PyTorch CPU: 
|    |    1e2 |     1e3 |    1e4 |     1e5 |      1e6 |      1e7 |
|----|--------|---------|--------|---------|----------|----------|
|  3 | 0.5915 |  0.6447 | 1.0245 |  7.629  |  57.9476 |  643.39  |
|  4 | 0.6751 |  0.7211 | 1.0178 |  7.3699 |  71.5828 |  895.599 |
|  5 | 1.6042 |  1.3475 | 1.7276 |  9.6214 | 133.742  | 1133.72  |
|  6 | 8.4555 | 11.9247 | 9.3707 | 19.098  | 148.791  | 1616.52  |

PyTorch CUDA: 
|    |    1e2 |    1e3 |    1e4 |    1e5 |     1e6 |     1e7 |
|----|--------|--------|--------|--------|---------|---------|
|  3 | 3.1708 | 3.2489 | 3.175  | 4.6245 | 15.231  | 122.855 |
|  4 | 3.7462 | 3.6169 | 3.6932 | 4.9276 | 16.779  | 136.683 |
|  5 | 4.2622 | 4.1095 | 4.1405 | 5.6287 | 20.4805 | 163.636 |
|  6 | 5.212  | 5.4013 | 5.5737 | 7.7179 | 29.4644 | 235.449 |

### Custom binning: 
Numpy: 
|    |     1e2 |     1e3 |     1e4 |     1e5 |     1e6 |     1e7 |
|----|---------|---------|---------|---------|---------|---------|
|  3 |  0.0942 |  0.1923 |  1.1195 | 10.3695 | 144.948 | 1840.42 |
|  4 |  0.1462 |  0.2816 |  1.5403 | 13.8997 | 198.91  | 2469.55 |
|  5 |  3.0384 |  3.1955 |  4.642  | 21.0965 | 255.263 | 3154.92 |
|  6 | 34.4577 | 35.5735 | 37.1265 | 58.566  | 422.356 | 3956.98 |

PyTorch CPU: 
|    |     1e2 |    1e3 |    1e4 |     1e5 |      1e6 |      1e7 |
|----|---------|--------|--------|---------|----------|----------|
|  3 |  0.3433 | 0.3851 | 1.1735 |  6.4706 |  67.2968 |  853.978 |
|  4 |  0.4135 | 0.4551 | 0.9737 |  9.0621 |  90.2246 | 1217.1   |
|  5 |  1.29   | 1.4303 | 1.7511 | 11.7872 | 108.467  | 1538.12  |
|  6 | 10.2312 | 7.6337 | 9.1426 | 22.4487 | 196.138  | 1948.4   |

PyTorch CUDA: 
|    |    1e2 |    1e3 |    1e4 |    1e5 |     1e6 |      1e7 |
|----|--------|--------|--------|--------|---------|----------|
|  3 | 1.4808 | 1.4575 | 1.5768 | 2.4007 | 10.5617 |  89.3735 |
|  4 | 1.5851 | 1.5787 | 1.6688 | 2.5035 | 11.0659 |  92.0011 |
|  5 | 1.8847 | 1.8446 | 1.8306 | 2.8386 | 12.6494 | 108.204  |
|  6 | 2.7251 | 2.6371 | 2.7562 | 4.2877 | 20.7345 | 168.842  |