### PR TITLE
PWGPP-581 performance fixes

### DIFF
--- a/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/benchmark_histogramdd_pytorch.py
@@ -23,6 +23,9 @@ torch.random.manual_seed(19680801)
 torch.cuda.manual_seed_all(19680801)
 np.random.seed(19680801)
 
+number = 5
+repeat = 4
+
 create_output_file = True
 
 def get_tensors(n,d=3,device=None):
@@ -76,60 +79,60 @@ for j in range(6):
                 stmt="histogramdd(sample)",
                 setup="sample = get_tensors(n,i,device='cpu')",
                 globals=globals(),
-                repeat=20,
-                number=1
+                repeat=repeat,
+                number=number
                 )
-        time_cpu[i-3,j] = min(t)
-        print("CPU: ",min(t),sep='\t')
+        time_cpu[i-3,j] = min(t)/number
+        print("CPU: ",min(t)/number,sep='\t')
         if torch.cuda.is_available():
             t = timeit.repeat(
                     stmt="histogramdd_synchronized(sample)",
                     setup="sample = get_tensors(n,i,device='cuda')",
                     globals=globals(),
-                    repeat=20,
-                    number=1
+                    repeat=repeat,
+                    number=number
                     )
-            time_cuda[i-3,j] = min(t)
-            print("CUDA: ",min(t),sep='\t')
+            time_cuda[i-3,j] = min(t)/number
+            print("CUDA: ",min(t)/number,sep='\t')
         t = timeit.repeat(
                 stmt="np.histogramdd(sample)",
                 setup="sample = get_arrays(n,i)",
                 globals=globals(),
-                repeat=20,
-                number=1
+                repeat=repeat,
+                number=number
                 )
-        time_numpy[i-3,j] = min(t)
-        print("Numpy: ",min(t),sep='\t')
+        time_numpy[i-3,j] = min(t)/number
+        print("Numpy: ",min(t)/number,sep='\t')
 
         if searchsorted_available:
             t = timeit.repeat(
                     stmt="histogramdd(sample,bins)",
                     setup="sample,bins = get_tensors_edges(n,i,device='cpu')",
                     globals=globals(),
-                    repeat=20,
-                    number=1
+                    repeat=repeat,
+                    number=number
                     )
-            time_cpu_e[i-3,j] = min(t)
-            print("CPU: ",min(t),sep='\t')
+            time_cpu_e[i-3,j] = min(t)/number
+            print("CPU: ",min(t)/number,sep='\t')
             if torch.cuda.is_available():
                 t = timeit.repeat(
                         stmt="histogramdd_synchronized(sample,bins)",
                         setup="sample,bins = get_tensors_edges(n,i,device='cuda')",
                         globals=globals(),
-                        repeat=20,
-                        number=1
+                        repeat=repeat,
+                        number=number
                         )
-                time_cuda_e[i-3,j] = min(t)
-                print("CUDA: ",min(t),sep='\t')
+                time_cuda_e[i-3,j] = min(t)/number
+                print("CUDA: ",min(t)/number,sep='\t')
             t = timeit.repeat(
                     stmt="np.histogramdd(sample,bins)",
                     setup="sample,bins = get_arrays_edges(n,i)",
                     globals=globals(),
-                    repeat=20,
-                    number=1
+                    repeat=repeat,
+                    number=number
                     )
-            time_numpy_e[i-3,j] = min(t)
-            print("Numpy: ",min(t),sep='\t')
+            time_numpy_e[i-3,j] = min(t)/number
+            print("Numpy: ",min(t)/number,sep='\t')
 
     n *= 10
 

--- a/RootInteractive/Tools/Histograms/histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/histogramdd_pytorch.py
@@ -88,7 +88,7 @@ def histogramdd(sample,bins=None,range=None,weights=None,remove_overflow=True):
             use_old_edges = True
             edges_old = edges
             m = max(i.size(0) for i in edges)
-            tmp = torch.empty([D,m],device=edges[0].device)
+            tmp = torch.full([D,m],float("inf"),device=edges[0].device)
             for i in _range(D):
                 s = edges[i].size(0)
                 tmp[i,:]=edges[i][-1]
@@ -140,7 +140,7 @@ def histogramdd(sample,bins=None,range=None,weights=None,remove_overflow=True):
     multiindex[1:] = torch.cumprod(torch.flip(bins[1:],[0])+2,-1).long()
     multiindex = torch.flip(multiindex,[0])
     l = torch.sum(k*multiindex.reshape(-1,1),0)
-    hist = torch.bincount(l,minlength=(multiindex[0]*(bins[0]+2)).item(),weights=weights)
+    hist = torch.bincount(l,minlength=(multiindex[0]*(bins[0]+2)),weights=weights)
     hist = hist.reshape(tuple(bins+2))
     if remove_overflow:
         core = D * (slice(1, -1),)

--- a/RootInteractive/Tools/Histograms/histogramdd_pytorch.py
+++ b/RootInteractive/Tools/Histograms/histogramdd_pytorch.py
@@ -139,7 +139,8 @@ def histogramdd(sample,bins=None,range=None,weights=None,remove_overflow=True):
     multiindex = torch.ones_like(bins)
     multiindex[1:] = torch.cumprod(torch.flip(bins[1:],[0])+2,-1).long()
     multiindex = torch.flip(multiindex,[0])
-    l = torch.sum(k*multiindex.reshape(-1,1),0)
+    k *= multiindex.reshape(-1,1)
+    l = torch.sum(k,0)
     hist = torch.bincount(l,minlength=(multiindex[0]*(bins[0]+2)),weights=weights)
     hist = hist.reshape(tuple(bins+2))
     if remove_overflow:


### PR DESCRIPTION
This pull request(followup to #50) should:
-Change the way the benchmark is computed, from a hardcoded min of 20 values to a parametrizable min of means
-Improve the performance of histogramdd slightly

New benchmark results (CPU: Intel Core i5-6300HQ CPU @ 2.30 GHz, GPU: NVidia GeForce GTX 950M)
## Benchmark results: 
### Uniform binning: 
Numpy: 
|    |      1e2 |      1e3 |      1e4 |     1e5 |     1e6 |     1e7 |
|----|----------|----------|----------|---------|---------|---------|
|  3 |  0.2047  |  0.37234 |  1.29736 | 11.5826 | 160.307 | 1949.61 |
|  4 |  0.28856 |  0.4475  |  1.7853  | 15.6678 | 224.898 | 2679.14 |
|  5 |  3.26502 |  3.43916 |  5.05264 | 23.2    | 298.145 | 3563.87 |
|  6 | 35.536   | 36.0726  | 37.91    | 62.9623 | 446.907 | 4461.89 |

PyTorch CPU: 
|    |     1e2 |     1e3 |      1e4 |      1e5 |      1e6 |      1e7 |
|----|---------|---------|----------|----------|----------|----------|
|  3 | 0.54516 | 0.6219  |  0.87394 |  5.00336 |  51.9611 |  617.155 |
|  4 | 0.6346  | 0.70688 |  0.91046 |  6.64064 |  68.6813 |  828.215 |
|  5 | 1.315   | 1.5724  |  1.7824  |  9.23358 |  86.1553 |  996.69  |
|  6 | 9.0458  | 8.83482 | 10.4992  | 18.8993  | 113.942  | 1303.51  |

PyTorch CUDA: 
|    |     1e2 |     1e3 |     1e4 |     1e5 |     1e6 |     1e7 |
|----|---------|---------|---------|---------|---------|---------|
|  3 | 3.5997  | 3.13592 | 3.44762 | 4.43924 | 15.8262 | 123.635 |
|  4 | 3.49984 | 3.58186 | 3.6918  | 4.89924 | 16.9513 | 136.894 |
|  5 | 4.05526 | 4.07444 | 4.11176 | 5.57086 | 20.1096 | 164.418 |
|  6 | 5.2349  | 5.10368 | 5.54308 | 7.56686 | 29.3824 | 235.171 |

### Custom binning: 
Numpy: 
|    |      1e2 |      1e3 |      1e4 |     1e5 |     1e6 |     1e7 |
|----|----------|----------|----------|---------|---------|---------|
|  3 |  0.09038 |  0.19528 |  1.1199  | 10.2813 | 146.961 | 1933.58 |
|  4 |  0.14918 |  0.26912 |  1.48472 | 14.6348 | 199.609 | 2435.01 |
|  5 |  3.07832 |  3.18404 |  4.77286 | 21.2951 | 259.497 | 3111.32 |
|  6 | 35.375   | 36.4771  | 37.7669  | 60.8223 | 421.322 | 3960.58 |

PyTorch CPU: 
|    |     1e2 |     1e3 |     1e4 |      1e5 |      1e6 |      1e7 |
|----|---------|---------|---------|----------|----------|----------|
|  3 | 0.35438 | 0.37402 | 0.79916 |  8.85088 |  63.4042 |  790.535 |
|  4 | 0.35934 | 0.44904 | 0.96622 |  7.81916 |  84.1634 | 1069.46  |
|  5 | 1.05216 | 1.14454 | 1.88604 | 11.0951  | 106.074  | 1321.54  |
|  6 | 8.4998  | 8.55474 | 9.58724 | 21.3451  | 176.664  | 1655.93  |

PyTorch CUDA: 
|    |     1e2 |     1e3 |     1e4 |     1e5 |     1e6 |      1e7 |
|----|---------|---------|---------|---------|---------|----------|
|  3 | 1.54112 | 1.4543  | 1.51164 | 2.70814 | 10.4972 |  89.9424 |
|  4 | 1.53066 | 1.72698 | 1.59492 | 2.61712 | 10.7991 |  91.8241 |
|  5 | 1.77102 | 1.77858 | 1.79876 | 2.84356 | 12.7051 | 108.067  |
|  6 | 2.6795  | 2.63414 | 2.84796 | 4.38072 | 19.7901 | 168.56   |

