### PR TITLE
Compatibility bokeh

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDraw.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDraw.py
@@ -291,7 +291,6 @@ class bokehDraw(object):
             else:
                 sliderQuery += str(str(iWidget.description) + "==" + str(iWidget.value) + "&")
         sliderQuery = sliderQuery[:-1]
-        #newSource = ColumnDataSource(self.dataSource.query(sliderQuery))
         self.bokehSource.data = self.dataSource.query(sliderQuery)
         # print(sliderQuery, newSource.data["index"].size)
         if self.verbosity & 1:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDraw.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDraw.py
@@ -37,23 +37,23 @@ class bokehDraw(object):
                                     Requires 1 or more parameters.
                                     dropdown.name(option1,option2,....)
                                       Ex: dropdown.MB(0,0.5,1)
-                                             
+
                                  to group widget you can use accordion or tab:
                                    Ex:
                                      accordion.group1(widget1,widget2...), accordion.group2(widget1,widget2...)
                                      tab.group1(widget1,widget2...), tab.group2(widget1,widget2...)
-                                         
+
         :param p:                template figure
         :param options:          optional drawing parameters
                                  - ncols - number fo columns in drawing
                                  - commonX=?,commonY=? - switch share axis
                                  - size
-                                 - errX=?  - query for errors on X-axis 
+                                 - errX=?  - query for errors on X-axis
                                  - errY=?  - array of queries for errors on Y
                                  Tree options:
-                                 - variables     - List of variables which will extract from ROOT File 
+                                 - variables     - List of variables which will extract from ROOT File
                                  - nEntries      - number of entries which will extract from ROOT File
-                                 - firstEntry    - Starting entry number 
+                                 - firstEntry    - Starting entry number
                                  - mask          - mask for variable names
                                  - verbosity     - first bit: verbosity for query for every update
                                                  - second bit: verbosity for source file.
@@ -168,7 +168,7 @@ class bokehDraw(object):
 
     def initWidgets(self, widgetString):
         r"""
-        Initialize widgets 
+        Initialize widgets
 
         :param widgetString:
             example string
@@ -291,8 +291,8 @@ class bokehDraw(object):
             else:
                 sliderQuery += str(str(iWidget.description) + "==" + str(iWidget.value) + "&")
         sliderQuery = sliderQuery[:-1]
-        newSource = ColumnDataSource(self.dataSource.query(sliderQuery))
-        self.bokehSource.data = newSource.data
+        #newSource = ColumnDataSource(self.dataSource.query(sliderQuery))
+        self.bokehSource.data = self.dataSource.query(sliderQuery)
         # print(sliderQuery, newSource.data["index"].size)
         if self.verbosity & 1:
             logging.info(sliderQuery)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -690,12 +690,12 @@ def bokehDrawArray(dataFrame, query, figureArray, **kwargs):
             figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=source, size=optionLocal['size'],
                             color=optionLocal["color"],
                             marker=optionLocal["marker"], legend_label=varY + " vs " + varX)
-            if ('errX' in optionLocal.keys()) & (optionLocal['errX'] !=''):
-                errors = HBar(y=varNameY, left=varNameX+"_lower", right=varNameX+"_upper",line_color=optionLocal["color"])
-                figureI.add_glyph(source,errors)
-            if ('errY' in optionLocal.keys()) & (optionLocal['errY'] !=''):
-                errors = VBar(x=varNameX, bottom=varNameY+"_lower", top=varNameY+"_upper",line_color=optionLocal["color"])
-                figureI.add_glyph(source,errors)
+            if ('errX' in optionLocal.keys()) & (optionLocal['errX'] != ''):
+                errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=optionLocal["color"])
+                figureI.add_glyph(source, errorX)
+            if ('errY' in optionLocal.keys()) & (optionLocal['errY'] != ''):
+                errorY = VBar(x=varNameX, width=0, bottom=varNameY+"_lower", top=varNameY+"_upper", line_color=optionLocal["color"])
+                figureI.add_glyph(source, errorY)
             #    errors = Band(base=varNameX, lower=varNameY+"_lower", upper=varNameY+"_upper",source=source)
             #    figureI.add_layout(errors)
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -52,8 +52,8 @@ def makeJScallback(widgetDict, **kwargs):
         code += f"var v{a} =dataOrig[\"{a}\"][i];\n"
         # code += f"var {a} =dataOrig[\"{a}\"][i];\n"
 
+    code += "let isOK = false;\n"
     for key, value in widgetDict.items():
-        #
         if isinstance(value, Slider):
             code += f"      var {key}Value={key}.value;\n"
             code += f"      var {key}Step={key}.step;\n"
@@ -770,7 +770,6 @@ def makeBokehSliderWidget(df, isRange, params, **kwargs):
     else:
         value = (start + end) * 0.5
         slider = Slider(title=title, start=start, end=end, step=step, value=value)
-    slider.callback_policy = 'mouseup'
     return slider
 
 


### PR DESCRIPTION
This PR fixes the compatibility of interactive drawing with Bokeh 2.2.3 by removing the deprecated CallbackPolicy field on sliders, fixing a JavaScript callback bug and fixing the line for updating the data source.

For some reason, the error bars are bigger than before on my machine, a hypothesis is that it's caused by the Bokeh update as the changes didn't touch the code responsible for that. - should be fixed by the last commit - was caused by error bar widths not being specified.