### PR TITLE
Fixed multiselect to work with floats, no longer works with strings

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -179,9 +179,14 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
         }
         if(widgetType == "MultiSelect"){
             const col = dataOrig[key];
-            const widgetValue = widget.value;
+            const widgetValue = widget.value.map((val)=>Number(val));
+            const widgetNSelected = widgetValue.length;
             for(let i=0; i<size; i++){
-                isSelected[i] &= (widgetValue.includes(col[i].toString()));
+                let isOK=0;
+                for(let j=0; j<widgetNSelected; j++){
+                    isOK |= Math.abs(widgetValue[j]-col[i])<precision;              
+                }
+                isSelected[i] &= isOK;
             }
         }
         if(widgetType == "CheckboxGroup"){

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -25,7 +25,7 @@ initMetadata(df)
 df.eval("Bool=A>0.5", inplace=True)
 df["AA"]=(df.A*10).round(0)/10.
 df["CC"]=(df.C*5).round(0)
-df["DD"]=(df.D*2).round(0)
+df["DD"]=(df.D*2).round(0)/2
 df["EE"]=(df.E*4).round(0)
 df['errY']=df.A*0.02+0.02;
 df.head(10)
@@ -53,7 +53,7 @@ widgetParams=[
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10}],
-    ['multiSelect', ["DD", 0, 1, 2, 3]],
+    ['multiSelect', ["DD", 0, .5, 1]],
     ['select',["CC", 0, 1, 2, 3]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
 ]
@@ -98,5 +98,5 @@ def testBokehDrawArraySA_tree():
 #testBokehDrawArraySA()
 #testBokehDrawArraySA_tree()
 #testBokehDrawArrayWidget()
-#testBokehDrawArrayWidgetNoScale()
+testBokehDrawArrayWidgetNoScale()
 #testBokehDrawArrayDownsample()


### PR DESCRIPTION
This PR fixes multiselect to work with floats, but breaks its compatibility with strings in the CDS. Should also slightly improve the performance. Also changes the tests to reflect that.