### PR TITLE
Client-side histogram - improved the performance slightly

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
@@ -1,5 +1,5 @@
-from bokeh.core.properties import Instance, String, Float, Int
-from bokeh.models import ColumnarDataSource, CDSView
+from bokeh.core.properties import Instance, String, Float, Int, List
+from bokeh.models import ColumnarDataSource
 
 
 class HistogramCDS(ColumnarDataSource):
@@ -15,7 +15,7 @@ class HistogramCDS(ColumnarDataSource):
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
 
     source = Instance(ColumnarDataSource)
-    view = Instance(CDSView)
+    view = List(Int)
     sample = String
     weights = String(default=None)
     nbins = Int

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -116,6 +116,7 @@ export class HistogramCDS extends ColumnarDataSource {
 
   private _range_min: number
   private _range_max: number
+  private _nbins: number
 
   update_range(): void {
       // TODO: This is a hack and can be done in a much more efficient way that doesn't save bin edges as an array
@@ -123,8 +124,9 @@ export class HistogramCDS extends ColumnarDataSource {
       const bin_right = (this.data["bin_right"] as number[])
       bin_left.length = 0
       bin_right.length = 0
-      this._range_min = this._range_min
-      this._range_max = this._range_max
+      this._range_min = this.range_min
+      this._range_max = this.range_max
+      this._nbins = this.nbins
       this._transform_scale = this.nbins/(this.range_max-this.range_min)
       this._transform_origin = -this.range_min*this._transform_scale
       for (let index = 0; index < this.nbins; index++) {
@@ -136,10 +138,10 @@ export class HistogramCDS extends ColumnarDataSource {
 
   getbin(val: number): number{
       // Overflow bins
-      if(val > this._range_max) return this.nbins
+      if(val > this._range_max) return this._nbins
       if(val < this._range_min) return -1
       // Make the max value inclusive
-      if(val === this._range_max) return this.nbins-1
+      if(val === this._range_max) return this._nbins-1
       // Compute the bin in the normal case
       return (val*this._transform_scale+this._transform_origin)|0
   }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -114,12 +114,17 @@ export class HistogramCDS extends ColumnarDataSource {
   private _transform_origin: number
   private _transform_scale: number
 
+  private _range_min: number
+  private _range_max: number
+
   update_range(): void {
       // TODO: This is a hack and can be done in a much more efficient way that doesn't save bin edges as an array
       const bin_left = (this.data["bin_left"] as number[])
       const bin_right = (this.data["bin_right"] as number[])
       bin_left.length = 0
       bin_right.length = 0
+      this._range_min = this._range_min
+      this._range_max = this._range_max
       this._transform_scale = this.nbins/(this.range_max-this.range_min)
       this._transform_origin = -this.range_min*this._transform_scale
       for (let index = 0; index < this.nbins; index++) {
@@ -131,10 +136,10 @@ export class HistogramCDS extends ColumnarDataSource {
 
   getbin(val: number): number{
       // Overflow bins
-      if(val > this.range_max) return this.nbins
-      if(val < this.range_min) return -1
+      if(val > this._range_max) return this.nbins
+      if(val < this._range_min) return -1
       // Make the max value inclusive
-      if(val === this.range_max) return this.nbins-1
+      if(val === this._range_max) return this.nbins-1
       // Compute the bin in the normal case
       return (val*this._transform_scale+this._transform_origin)|0
   }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -90,7 +90,7 @@ class bokehDrawSA(object):
         self.pAll=gridplotRow(self.plotArray)
         self.handle=show(self.pAll,notebook_handle=self.isNotebook)
         self.cmapDist = None
-        self.view = None
+        self.histoList = None
 
     @classmethod
     def fromArray(cls, dataFrame, query, figureArray, widgetsDescription, **kwargs):
@@ -135,7 +135,7 @@ class bokehDrawSA(object):
                 varList+=w[1][0]+":"
         kwargs["optionList"]=optionList
         self = cls(dataFrame, query, "", "", "", "", None, variables=varList, **kwargs)
-        self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapDict, self.cdsOrig, self.view = bokehDrawArray(self.dataSource, query,
+        self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapDict, self.cdsOrig, self.histoList = bokehDrawArray(self.dataSource, query,
                                                                                                 figureArray, **kwargs)
         # self.cdsOrig=ColumnDataSource(dataFrameOrig)
         #self.Widgets = self.initWidgets(widgetString)
@@ -157,7 +157,7 @@ class bokehDrawSA(object):
         :return: VBox includes all widgets
         """
         if type(widgetsDescription)==list:
-            widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.view, self.cmapDict, nPointRender = self.options['nPointRender'])
+            widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList, self.cmapDict, nPointRender = self.options['nPointRender'])
             if isinstance(self.widgetLayout,list):
                 widgetList=processBokehLayoutArray(self.widgetLayout, widgetList)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -220,11 +220,6 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
              }
         }*/
     }
-    const view = options.view;
-    if(view != null){
-        view.filters[0].booleans = isSelected;
-        view.compute_indices();
-    }
     for (let i = 0; i < size; i++){
         let randomIndex = 0;
         if (isSelected[i]){
@@ -247,6 +242,13 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
     }
     const t1 = performance.now();
     console.log(`Filtering took ${t1 - t0} milliseconds.`);
+    const view = options.view;
+    if(view != null){
+        view.filters[0].booleans = isSelected;
+        view.compute_indices();
+    }
+    const t2 = performance.now();
+    console.log(`Histogramming took ${t2 - t1} milliseconds.`);
     const cmapDict = options.cmapDict;
     if (cmapDict !== undefined && nSelected !== 0){
         for(const key in cmapDict){
@@ -261,11 +263,11 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
             }
         }
     }
-    const t2 = performance.now();
-    console.log(`Updating colormaps took ${t2 - t1} milliseconds.`);
-    cdsSel.change.emit();
     const t3 = performance.now();
-    console.log(`Updating cds took ${t3 - t2} milliseconds.`);
+    console.log(`Updating colormaps took ${t3 - t2} milliseconds.`);
+    cdsSel.change.emit();
+    const t4 = performance.now();
+    console.log(`Updating cds took ${t4 - t3} milliseconds.`);
     console.log(\"nSelected:%d\",nSelected);  
     """
     if options["verbose"] > 0:


### PR DESCRIPTION
This PR adds histogram bin caching to the client-side histograms feature, optimizing the time needed to compute the histogram, resulting in a factor of something over 2 of improvement. The change to makeJSCallback adds a debug log that measures the time taken computing the histograms.