### PR TITLE
Changing client-side histogramming to new interface

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
@@ -19,6 +19,5 @@ class HistogramCDS(ColumnarDataSource):
     sample = String
     weights = String(default=None)
     nbins = Int
-    range_min = Float
-    range_max = Float
+    range = List(Float)
     print("x", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -733,7 +733,7 @@ def parseWidgetString(widgetString):
     return widgetList
 
 
-def bokehDrawArray(dataFrame, query, figureArray, **kwargs):
+def bokehDrawArray(dataFrame, query, figureArray, histogramArray={}, **kwargs):
     """
     Wrapper bokeh draw array of figures
 
@@ -776,11 +776,9 @@ def bokehDrawArray(dataFrame, query, figureArray, **kwargs):
         "rescaleColorMapper": False,
         "filter": '',
         'doDraw': 0,
-        "legend_field":None,
+        "legend_field": None,
         'nPointRender': 100000,
         "nbins": 10,
-        "range_min": 0,
-        "range_max": 1,
         "weights": None,
         "histo2d": False,
         "range": None
@@ -839,10 +837,11 @@ def bokehDrawArray(dataFrame, query, figureArray, **kwargs):
         logging.error("Invalid source:", source)
     # define default options
 
+    histoList = []
+
     plotArray = []
     colorAll = all_palettes[options['colors']]
     colorMapperDict = {}
-    histoList = []
     if isinstance(figureArray[-1], dict):
         options.update(figureArray[-1])
     for i, variables in enumerate(figureArray):
@@ -939,8 +938,8 @@ def bokehDrawArray(dataFrame, query, figureArray, **kwargs):
             varY = variables[1][i % lengthY]
 
             if varY == "histo":
-                cdsHisto = HistogramCDS(source=cdsFull, nbins=optionLocal["nbins"], range_min=optionLocal["range_min"],
-                                        range_max=optionLocal["range_max"], sample=varNameX, weights=optionLocal["weights"])
+                cdsHisto = HistogramCDS(source=cdsFull, nbins=optionLocal["nbins"],
+                                        range=optionLocal["range"], sample=varNameX, weights=optionLocal["weights"])
                 histoList.append(cdsHisto)
                 colorHisto = colorAll[max(length, 4)][i]
                 if optionLocal['color'] is not None:
@@ -1131,3 +1130,11 @@ def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDi
             iWidget.js_on_change("value", callback)
         iWidget.js_on_event("value", callback)
     return widgetArray
+
+
+def bokehMakeHistogramCDS(cdsOrig, histogramArray=[]):
+    histoDict = {}
+    for iHisto in histogramArray:
+        sampleVars = iHisto["variables"]
+        histoName = iHisto["name"]
+    return histoDict

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -56,9 +56,9 @@ def testBokehClientHistogram():
         [['(A+B)/2'], ['histo', '(C+A)*200', '(C-A)*200'], {"weights": "C"}],
         [['B'], ['histo', '(C+B)*10', '(C-B)*10'], {"size": 7, "colorZvar": "C", "errY": "errY",
                                                     "rescaleColorMapper": True, "nbins": 100,
-                                                    "range_min": 0, "range_max": 1}]
+                                                    "range": [0, 1]}]
     ]
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode="scale_width")
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointsRender=3000)
 
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -48,27 +48,30 @@ figureLayoutDesc=[
     {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
 ]
 
+histoArray = [
+    {"name": "histo1", "variables": ["A"]},
+    {"name": "histoTransform", "variables": ["(A+B)/2"]},
+    {"name": "histo2", "variables": ["A", "B"], "nbins": [20, 20], "weights": "D"}
+]
+
 def testBokehClientHistogram():
     output_file("test_BokehClientHistogram.html")
     figureArray = [
         #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
-        [['A'], ['histo', '(A*A-C*C)*100'], {"size": 2, "colorZvar": "A", "errY": "errY", "errX": "0.01"}],
-        [['(A+B)/2'], ['histo', '(C+A)*200', '(C-A)*200'], {"weights": "C"}],
-        [['B'], ['histo', '(C+B)*10', '(C-B)*10'], {"size": 7, "colorZvar": "C", "errY": "errY",
-                                                    "rescaleColorMapper": True, "nbins": 100,
-                                                    "range": [0, 1]}]
+        [['A'], ['histo1', '(A*A-C*C)*100'], {"size": 2, "colorZvar": "A", "errY": "errY", "errX": "0.01"}],
+        [['(A+B)/2'], ['histoTransform', '(C+A)*200', '(C-A)*200']],
+        [['B'], ['histo2', '(C+B)*10', '(C-B)*10'], {"size": 7, "colorZvar": "C", "errY": "errY",
+                                                    "rescaleColorMapper": True}]
     ]
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointsRender=3000)
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointsRender=3000, histogramArray=histoArray)
 
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
-    histoArray = [
-        {"name": "histo1", "variables": ["A"]}
-    ]
     figureArray = [
         [['A'], ['histo1']],
-        [['(A+B)/2'], ['histo'], {"weights": "D"}],
-        [['A'], ['B'], {"nbins": [20, 20], "histo2d": True, "weights": "D"}]
+        [['(A+B)/2'], ['histoTransform']],
+        [['A'], ['histo2']]
     ]
     xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -62,12 +62,16 @@ def testBokehClientHistogram():
 
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
+    histoArray = [
+        {"name": "histo1", "variables": ["A"]}
+    ]
     figureArray = [
-        [['A'], ['histo']],
+        [['A'], ['histo1']],
         [['(A+B)/2'], ['histo'], {"weights": "D"}],
         [['A'], ['B'], {"nbins": [20, 20], "histo2d": True, "weights": "D"}]
     ]
-    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc,sizing_mode="scale_width")
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                                widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 # testBokehClientHistogram()
 testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -16,10 +16,10 @@ def makePanda(step,sigma):
 
 
 figureArray = [
-    [['A'], ['histo'], { "weights": "Wa","nbins": 50,"range_min": -1, "range_max": 1}],
-    [['A'], ['histo'], { "weights": "W","nbins": 50,"range_min": -1, "range_max": 1}],
-    [['B'], ['histo'], { "weights": "W","nbins": 50,"range_min": -1, "range_max": 1}],
-    [['D'], ['histo'], { "weights": "W","nbins": 50,"range_min": -1, "range_max": 1}],
+    [['A'], ['histo'], { "weights": "Wa","nbins": 50, "range": [-1, 1]}],
+    [['A'], ['histo'], { "weights": "W","nbins": 50, "range": [-1, 1]}],
+    [['B'], ['histo'], { "weights": "W","nbins": 50, "range": [-1, 1]}],
+    [['D'], ['histo'], { "weights": "W","nbins": 50, "range": [-1, 1]}],
 ]
 widgetParams = [
     ['range', ['A',-1., 1., 0.1, -1., 1.]],


### PR DESCRIPTION
This PR updates client-side histogramming using bokeh to the new interface in #90 and changes two tests to reflect it. This change is not backward compatible with the old interface in the 1D case, as it now accepts a sequence of floats as the range argument, which can be null for auto range, instead of accepting range_min and range_max.