### PR TITLE
Added colZ visualization for clientside histograms

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
@@ -62,13 +62,17 @@ def histogramDCAPlot(df):
     output_file("dcaCompressionDemo.html")
     optionsAll = {"colorZvar": "mdEdxCenter"}
     df["Vcorr"] = df["V"] - df["mean"]
+    histogramArray = [
+        {"name": "histoV", "variables": ["V"], "range": [-2, 2], "weights": "weight", "nbins": 100},
+        {"name": "histoVcorr", "variables": ["Vcorr"], "range": [-2, 2], "weights": "weight", "nbins": 100}
+    ]
     figureArray = [
         [['qPtCenter'], ['mean'], optionsAll],
         [['tglCenter'], ['mean'], optionsAll],
         [['qPtCenter'], ['tglCenter'], {"color": "red", "size": 2, "colorZvar": "mean", "varZ": "mean"}],
         [['V'], ['weight'], optionsAll],
-        [['V'], ['histo'], {"range_min": -2, "range_max": 2, "weights": "weight", "nbins": 100}],
-        [['Vcorr'], ['histo'], {"range_min": -2, "range_max": 2, "weights": "weight", "nbins": 100}],
+        [['V'], ['histoV']],
+        [['Vcorr'], ['histoVcorr']],
     ]
 
     widgetParams = [
@@ -87,7 +91,7 @@ def histogramDCAPlot(df):
     ]
     fig = bokehDrawSA.fromArray(df.query("(index%27)==0"), "weight>0", figureArray, widgetParams, layout=figureLayoutDesc,
                                 tooltips=tooltips, sizing_mode='scale_width', widgetLayout=widgetLayoutDesc,
-                                nPointRender=5000, rescaleColorMapper=True)
+                                nPointRender=5000, rescaleColorMapper=True, histogramArray=histogramArray)
 
 def mitest_roundRelativeBinary(df):
     """

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -71,7 +71,7 @@ def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
     figureArray = [
         [['A'], ['histoA']],
-        [['(A+B)/2'], ['histoTransform']],
+        [['A'], ['histoAB'], {"visualization_type": "colZ"}],
         [['A'], ['histoAB']],
         [['B'], ['histoB']]
     ]
@@ -84,4 +84,4 @@ def testBokehClientHistogramOnlyHisto():
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 #testBokehClientHistogram()
-#testBokehClientHistogramOnlyHisto()
+testBokehClientHistogramOnlyHisto()


### PR DESCRIPTION
This PR:

Changes test_Compression.py to use new histogram interface
Extracts more functions from bokehDrawArray
Implements the functionality to use multiple visualization types for 2D histograms. So far, the implemented ones are "heatmap" and "colZ" Example in test_bokehClientHistogram.py

Related to #90