### PR TITLE
Compression array - optional compression of CDS before sending to client (or saving) #96 

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.py
@@ -3,7 +3,7 @@ from bokeh.models import ColumnarDataSource
 
 
 class CDSCompress(ColumnarDataSource):
-    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.2/pako.min.js"]
+    __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.2/pako.min.js","https://cdnjs.cloudflare.com/ajax/libs/Base64/1.1.0/base64.js"]
     __implementation__ = "CDSCompress.ts"
 
     # Below are all the "properties" for this model. Bokeh properties are

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -1,6 +1,8 @@
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import {ColumnDataSource} from "models/sources/column_data_source"
 import * as p from "core/properties"
+declare var Buffer : any
+declare var pako : any
 
 export namespace CDSCompress {
   export type Attrs = p.AttrsOf<Props>
@@ -32,11 +34,65 @@ export class CDSCompress extends ColumnarDataSource {
 
   initialize(): void {
     super.initialize()
-    this.data = {}
+    //this.data = {}
     console.info("CDSCompress::initialize")
+    this.inflateCompressedBokehObjectBase64()
     //this.update_range()
   }
+  inflateCompressedBokehBase64(arrayIn: any ) {
+    let arrayOut=arrayIn.array
+    for(var i =  arrayIn.actionArray.length-1;i>=0; i--) {
+      console.log((i + 1) + " --> " + arrayIn.actionArray[i])
+      if (arrayIn.actionArray[i][0] == "base64") {
+        //arrayOut=Buffer.from(arrayOut, 'base64');
+        arrayOut = atob(arrayOut).split("").map(function (x) {
+          return x.charCodeAt(0);
+        });
+      }
+      if (arrayIn.actionArray[i][0] == "zip") {
+        //arrayOut=Buffer.from(arrayOut, 'base64');
+        //var myArr = new Uint8Array(arrayOut)
+        arrayOut = pako.inflate(arrayOut)
+        if (arrayIn.indexType=="int16"){
+          arrayOut=new Uint16Array(arrayOut.buffer);
+        }
+        if (arrayIn.indexType=="int32"){
+          arrayOut=new Uint32Array(arrayOut.buffer);
+        }
+        console.log(arrayOut)
+      }
+      if (arrayIn.actionArray[i][0] == "code") {
+        let size = arrayOut.length;
+        let arrayOutNew = new Array();
+        for (let i = 0; i < size; i++) {
+          arrayOutNew.push(arrayIn.valueCode[arrayOut[i]]);
+        }
+        arrayOut=arrayOutNew
+      }
+    }
+    return arrayOut
+    //arrayIn.actionArray.reverse().forEach(x => console.log(x))
+  }
 
+  inflateCompressedBokehObjectBase64() {
+    this.data = {};
+    let objectOut0 = Object;
+    let objectOut = (objectOut0 as any);
+    let objectIn = (this.inputData as any);
+    let length=0;
+    for (let arr in objectIn) {
+      let arrOut = this.inflateCompressedBokehBase64(objectIn[arr]);
+      this.data[arr]=arrOut;
+      //if (arrOut.length!=length)
+      length=arrOut.length
+      console.log(arr);
+    }
+    this.data["index"]=new Uint32Array(length)
+     for (let i = 0; i < length; i++) {
+         this.data["index"][i]=i;
+        }
+    return objectOut
+  }
 
   public view: number[] | null
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -157,7 +157,8 @@ class bokehDrawSA(object):
         :return: VBox includes all widgets
         """
         if type(widgetsDescription)==list:
-            widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList, self.cmapDict, nPointRender = self.options['nPointRender'])
+            widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList,
+                                         self.cmapDict, nPointRender = self.options['nPointRender'])
             if isinstance(self.widgetLayout, list):
                 widgetList=processBokehLayoutArray(self.widgetLayout, widgetList)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -34,6 +34,7 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
     code = \
         """
     const t0 = performance.now();
+    const dataOrig = cdsOrig.data;
     let dataSel = null;
     if(cdsSel != null){
         dataSel = cdsSel.data;

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -27,7 +27,6 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
         "verbose": 0,
         "nPointRender": 10000,
         "cmapDict": None,
-        "cdsCompress":None,
         "histogramList": []
     }
     options.update(kwargs)
@@ -35,8 +34,6 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
     code = \
         """
     const t0 = performance.now();
-    const dataOrig = cdsOrig.data;
-    const cdsCompress = options["cdsCompress"];
     let dataSel = null;
     if(cdsSel != null){
         dataSel = cdsSel.data;
@@ -467,7 +464,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], **kwargs):
         "histo2d": False,
         "range": None,
         "flip_histogram_axes": False,
-        "show_histogram_error": False
+        "show_histogram_error": False,
+        "arrayCompression": None
     }
     options.update(kwargs)
     dfQuery = dataFrame.query(query)
@@ -640,6 +638,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], **kwargs):
         layoutList = [pAll]
     if options['doDraw'] > 0:
         show(pAll)
+    cdsCompress=None
+    if options['arrayCompression'] is not None:
+        print("compressCDSPipe")
+        cdsCompress0= compressCDSPipe(dfQuery,options["arrayCompression"],1)
+        cdsCompress=CDSCompress(source=None,inputData=cdsCompress0)
+        cdsFull=cdsCompress
     return pAll, source, layoutList, dfQuery, colorMapperDict, cdsFull, histoList
 
 
@@ -810,7 +814,7 @@ def makeBokehCheckboxWidget(df, params, **kwargs):
     return CheckboxGroup(labels=optionsPlot, active=[])
 
 
-def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDict=None, nPointRender=10000):
+def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDict=None, nPointRender=10000,cdsCompress=None):
     widgetArray = []
     widgetDict = {}
     for widget in widgetParams:
@@ -834,7 +838,6 @@ def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDi
             widgetArray.append(localWidget)
         widgetDict[params[0]] = localWidget
     # callback = makeJScallback(widgetDict, nPointRender=nPointRender)
-    cdsCompress=CDSCompress(source=cdsOrig,inputData=codeCDS(df,1))
     callback = makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, histogramList=histogramList, cmapDict=cmapDict, nPointRender=nPointRender, cdsCompress=cdsCompress)
     #callback = makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, histogramList=histogramList, cmapDict=cmapDict, nPointRender=nPointRender)
     for iWidget in widgetArray:

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
@@ -250,12 +250,12 @@ def testCompressionDecompressionInt16(stop=10, step=1):
     if diffSum > 0:
         raise ValueError("testCompressionDecompressionInt16 error")
 
-def test_compressCDSPipe(df):
+def test_compressCDSPipe():
+    df = simulatePandaDCA(True)
     actionArrayDelta=[("delta",0.01), ("code",0), ("zip",0), ("base64",0)]
     actionArrayRel=[("relative",8), ("code",0), ("zip",0), ("base64",0)]
     actionArrayRel4=[("relative",4), ("code",0), ("zip",0), ("base64",0)]
     arrayCompression=[ (".*Center",actionArrayDelta), (".*MeanD",actionArrayRel4),(".*",actionArrayRel)]
-    arrayCompression=[(".*",("relative",16), ("code",0), ("zip",0), ("base64",0))]
     #
     outputMap=compressCDSPipe(df,arrayCompression,1)
     return outputMap
@@ -292,4 +292,4 @@ def test_CompressionCDSPipeDraw():
     #print("test_CompressionCDSPipeDraw",size8,sizeNo, size8/sizeNo)
     return df
 
-df = test_CompressionCDSPipeDraw()
+#df = test_CompressionCDSPipeDraw()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
@@ -4,7 +4,7 @@ from scipy.stats import entropy
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
 from RootInteractive.Tools.compressArray import *
 import time
-
+import re
 # TODO
 #      if (User coding){
 #          float-> integer
@@ -50,10 +50,10 @@ def simulatePandaDCA(fastTest=False):
     H = weightPoisson
     df = pd.DataFrame({"qPtCenter": qPtCenter, "tglCenter": tgl, "mdEdxCenter": mdEdx, "alphaCenter": alpha, "V": value,
                        "mean": valueMean, "rms": valueSigma, "weight": H})
-    df["qPtMean"]=np.random.normal(df["qPtCenter"],0.05)
-    df["tglMean"]=np.random.normal(df["tglCenter"],0.05)
-    df["mdEdxMean"]=np.random.normal(df["mdEdxCenter"],0.05)
-    df["alphaMean"]=np.random.normal(df["alphaCenter"],0.05)
+    df["qPtMeanD"]=np.random.normal(df["qPtCenter"]*0,0.05)
+    df["tglMeanD"]=np.random.normal(df["tglCenter"]*0,0.05)
+    df["mdEdxMeanD"]=np.random.normal(df["tglCenter"]*0,0.05)
+    df["alphaMeanD"]=np.random.normal(df["alphaCenter"]*0,0.05)
     return df
 
 
@@ -196,7 +196,7 @@ def test_CompressionSampleDelta(arraySize=10000,scale=255, delta=1):
         arrayC = compressArray(arrayInput,actionArray, True)
         toc = time.perf_counter()
         compSize=getSize(arrayC["history"][2])
-        print("test_CompressionSampleRel: {}\t{}\t{:04f}\t{}\t{}\t{}".format(coding, arraySize, toc - tic, inputSize, compSize/inputSize, np.sqrt(((arrayC["array"]-arrayInput)**2).sum()/arraySize)))
+        print("test_CompressionSampleDelta: {}\t{}\t{:04f}\t{}\t{}\t{}".format(coding, arraySize, toc - tic, inputSize, compSize/inputSize, np.sqrt(((arrayC["array"]-arrayInput)**2).sum()/arraySize)))
 
 def test_CompressionSampleDeltaCode(arraySize=10000,scale=255, delta=1):
     actionArray=[("delta",delta), ("code",0), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8"),("decode",0)]
@@ -249,3 +249,47 @@ def testCompressionDecompressionInt16(stop=10, step=1):
     diffSum = (t5 - t0).sum()
     if diffSum > 0:
         raise ValueError("testCompressionDecompressionInt16 error")
+
+def test_compressCDSPipe(df):
+    actionArrayDelta=[("delta",0.01), ("code",0), ("zip",0), ("base64",0)]
+    actionArrayRel=[("relative",8), ("code",0), ("zip",0), ("base64",0)]
+    actionArrayRel4=[("relative",4), ("code",0), ("zip",0), ("base64",0)]
+    arrayCompression=[ (".*Center",actionArrayDelta), (".*MeanD",actionArrayRel4),(".*",actionArrayRel)]
+    arrayCompression=[(".*",("relative",16), ("code",0), ("zip",0), ("base64",0))]
+    #
+    outputMap=compressCDSPipe(df,arrayCompression,1)
+    return outputMap
+
+def test_CompressionCDSPipeDraw():
+    df = pd.DataFrame(np.random.random_sample(size=(100000, 4)), columns=list('ABCD'))
+    figureArray = [
+       [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "errY": "0.1", "errX":"0.01"}],
+        [['A'], ['C+A', 'C-A', 'A/A']],
+        [['B'], ['C+B', 'C-B'], { "size": 7, "colorZvar": "C",  "rescaleColorMapper": True }],
+        [['D'], ['(A+B+C)*D'], {"size": 10} ],
+    ]
+    tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)")]
+    widgetParams=[
+        ['range', ['A']],
+        ['range', ['B', 0, 1, 0.1, 0, 1]],
+        ['range', ['C'], {'type': 'minmax'}],
+        ['range', ['D'], {'type': 'minmax'}]
+    ]
+    widgetLayoutDesc=[[0, 1], [2, 3], {'sizing_mode': 'scale_width'}]
+    figureLayoutDesc=[
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'plot_height': 200, 'x_visible': 1, 'y_visible': 2}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
+    ]
+    output_file("test_CompressionCDSPipeDrawComp8.html")
+    xComp8=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                            widgetLayout=widgetLayoutDesc, nPointRender=200,arrayCompression=arrayCompressionRelative8)
+    output_file("test_CompressionCDSPipeDrawCompNo.html")
+    xCompNo=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                            widgetLayout=widgetLayoutDesc, nPointRender=200)
+    #size8=getSize(xComp8)
+    #sizeNo=getSize(xCompNo)
+    #print("test_CompressionCDSPipeDraw",size8,sizeNo, size8/sizeNo)
+    return df
+
+df = test_CompressionCDSPipeDraw()


### PR DESCRIPTION
Relates to #96
## Example usage with relative compression for all variables:
compression can be setup for each column separatelly

```
   arrayCompressionRelative8=[(".*",[("relative",8), ("code",0), ("zip",0), ("base64",0)])]
   xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                              widgetLayout=widgetLayoutDesc, nPointRender=200,arrayCompression=arrayCompressionRelative8)
```