### PR TITLE
Histogram stats table formatting

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.ts
@@ -94,9 +94,9 @@ export class HistoStatsCDS extends ColumnDataSource {
 
         }
         if(this.rowwise){
-          this.data = {"description":["mean", "std", "entries", "is_ok"]}
+          this.data = {"description":["mean", "std", "entries"]}
           for (let i = 0; i < this.names.length; i++) {
-            this.data[this.names[i]] = [mean_column[i], std_column[i], entries_column[i], isOK_column[i]]
+            this.data[this.names[i]] = [mean_column[i], std_column[i], entries_column[i]]
           }
         } else {
           this.data = {"name": this.names, "mean": mean_column, "std": std_column, "entries": entries_column, "isOK": isOK_column}

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.ts
@@ -38,6 +38,10 @@ export class HistoStatsCDS extends ColumnDataSource {
 
   initialize(): void {
     super.initialize()
+    // Hack to make this work with bokeh datatable - updating data triggers datatable update no matter what
+    if(this.rowwise){
+      this.data = {"description":["mean", "std", "entries"]}
+    }
     this.update()
   }
 
@@ -94,7 +98,7 @@ export class HistoStatsCDS extends ColumnDataSource {
 
         }
         if(this.rowwise){
-          this.data = {"description":["mean", "std", "entries"]}
+          //this.data = {"description":["mean", "std", "entries"]}
           for (let i = 0; i < this.names.length; i++) {
             this.data[this.names[i]] = [mean_column[i], std_column[i], entries_column[i]]
           }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,5 +1,6 @@
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import ColumnDataSource, ColorBar, HoverTool, CDSView, GroupFilter, VBar, HBar, Quad, Image
+from bokeh.models.widgets.tables import ScientificFormatter, DataTable
 from bokeh.transform import *
 from RootInteractive.Tools.aliTreePlayer import *
 # from bokehTools import *
@@ -430,6 +431,11 @@ def makeBokehHistoTable(histoDict, rowwise=False, **kwargs):
     bin_centers = []
     sources = []
 
+    if "formatter" in kwargs:
+        formatter = kwargs["formatter"]
+    else:
+        formatter = ScientificFormatter(precision=3)
+
     for iHisto in histoDict:
         if histoDict[iHisto]["type"] == "histo2d":
             histo_names.append(histoDict[iHisto]["name"]+"_X")
@@ -449,11 +455,11 @@ def makeBokehHistoTable(histoDict, rowwise=False, **kwargs):
     if rowwise:
         columns = [TableColumn(field="description")]
         for i in histo_names:
-            columns.append(TableColumn(field=i))
+            columns.append(TableColumn(field=i, formatter=formatter))
         data_table = DataTable(source=stats_cds, columns=columns, **kwargs)
     else:
-        data_table = DataTable(source=stats_cds, columns=[TableColumn(field="name"), TableColumn(field="mean"),
-                                                          TableColumn(field="std"), TableColumn(field="entries")],
+        data_table = DataTable(source=stats_cds, columns=[TableColumn(field="name"), TableColumn(field="mean", formatter=formatter),
+                                                          TableColumn(field="std", formatter=formatter), TableColumn(field="entries", formatter=formatter)],
                                **kwargs)
     return stats_cds, data_table
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -26,7 +26,13 @@ bokehMarkers = ["square", "circle", "triangle", "diamond", "squarecross", "circl
 
 # default tooltips for 1D and 2D histograms
 defaultHistoTooltips = [
-    ("range", "[@{bin_left}, {@{bin_right}]"),
+    ("range", "[@{bin_left}, @{bin_right}]"),
+    ("count", "@bin_count")
+]
+
+defaultHisto2DTooltips = [
+    ("range X", "[@{bin_left}, @{bin_right}]"),
+    ("range Y", "[@{bin_bottom}, @{bin_top}]"),
     ("count", "@bin_count")
 ]
 
@@ -488,6 +494,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], **kwargs):
         'tools': 'pan,box_zoom, wheel_zoom,box_select,lasso_select,reset,save',
         'tooltips': [],
         'histoTooltips': defaultHistoTooltips,
+        'histo2dTooltips': defaultHisto2DTooltips,
         'y_axis_type': 'auto',
         'x_axis_type': 'auto',
         'plot_width': 600,
@@ -726,7 +733,7 @@ def addHisto2dGlyph(fig, x, y, histoHandle, colorMapperDict, color, marker, dfQu
     if "tooltips" in histoHandle:
         tooltips = histoHandle["tooltips"]
     elif "tooltips" in options:
-        tooltips = options["histoTooltips"]
+        tooltips = options["histo2dTooltips"]
 
     if visualization_type == "heatmap":
         # Flipping histogram axes probably doesn't make sense in this case.

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -86,7 +86,7 @@ def testBokehClientHistogramOnlyHisto():
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 def testBokehClientHistogramRowwiseTable():
-    output_file("test_BokehClientHistogramOnlyHisto.html")
+    output_file("test_BokehClientHistogramRowwiseTable.html")
     figureArray = [
         [['A'], ['histoA']],
         [['A'], ['histoAB'], {"visualization_type": "colZ", "show_histogram_error": True}],
@@ -105,4 +105,4 @@ def testBokehClientHistogramRowwiseTable():
 
 #testBokehClientHistogram()
 #testBokehClientHistogramOnlyHisto()
-testBokehClientHistogramRowwiseTable()
+#testBokehClientHistogramRowwiseTable()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -74,7 +74,7 @@ def testBokehClientHistogramOnlyHisto():
         [['A'], ['histoAB'], {"visualization_type": "colZ", "show_histogram_error": True}],
         [['A'], ['histoAB']],
         [['B'], ['histoB'], {"flip_histogram_axes": True}],
-        ["tableHisto", {"rowwise": True}]
+        ["tableHisto", {"rowwise": False}]
     ]
     figureLayoutDesc=[
         [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -85,5 +85,24 @@ def testBokehClientHistogramOnlyHisto():
     xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
+def testBokehClientHistogramRowwiseTable():
+    output_file("test_BokehClientHistogramOnlyHisto.html")
+    figureArray = [
+        [['A'], ['histoA']],
+        [['A'], ['histoAB'], {"visualization_type": "colZ", "show_histogram_error": True}],
+        [['A'], ['histoAB']],
+        [['B'], ['histoB'], {"flip_histogram_axes": True}],
+        ["tableHisto", {"rowwise": True}]
+    ]
+    figureLayoutDesc=[
+        [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [4, {'plot_height': 40}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
+    ]
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                                widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
+
 #testBokehClientHistogram()
-testBokehClientHistogramOnlyHisto()
+#testBokehClientHistogramOnlyHisto()
+testBokehClientHistogramRowwiseTable()


### PR DESCRIPTION
This PR:
Fixes a typo in the default tooltips for histograms
Adds a formatter option for histogram stats table - default is a precision of 3 decimals, with fixed notation between 1e-4 and 1e5
Removes the isOK row from the stats table in case columns are the histograms