### PR TITLE
Fixed a bug with auto axis titles causing crashes for some 1D histograms

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1194,8 +1194,13 @@ def getHistogramAxisTitle(histoDict, varName, cdsName, removeCdsName=True):
         return varName
     if cdsName in histoDict:
         if '_' in varName:
+            if varName == "bin_count":
+                # Maybe do something else
+                return "count"
             x = varName.split("_")
             if x[0] == "bin":
+                if len(x) == 2:
+                    return histoDict[cdsName]["variables"][0]
                 return histoDict[cdsName]["variables"][int(x[-1])]
             if x[0] == "quantile":
                 quantile = histoDict[cdsName]["quantiles"][int(x[-1])]


### PR DESCRIPTION
When making the jupyter notebook, I have encountered a crash, running pytest has revealed that test_bokehClientHistogramWeight.py has failed because of a crash when generating the axi labels for 1D histogram. This PR should fix it.