### PR TITLE
Fix for compression with NaN values

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1194,8 +1194,13 @@ def getHistogramAxisTitle(histoDict, varName, cdsName, removeCdsName=True):
         return varName
     if cdsName in histoDict:
         if '_' in varName:
+            if varName == "bin_count":
+                # Maybe do something else
+                return "count"
             x = varName.split("_")
             if x[0] == "bin":
+                if len(x) == 2:
+                    return histoDict[cdsName]["variables"][0]
                 return histoDict[cdsName]["variables"][int(x[-1])]
             if x[0] == "quantile":
                 quantile = histoDict[cdsName]["quantiles"][int(x[-1])]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -11,6 +11,7 @@ def makePanda(step,sigma):
     cc = np.arange(-2, 2, step)
     a, b, c = np.meshgrid(aa, bb, cc, sparse=False)
     w = np.exp(-(np.abs(a - b) ** 2) / (2 * sigma ** 2))
+    #w[0] = np.NaN
     wA = np.exp(-(a ** 2) / (2 * sigma ** 2))
     df0 = pd.DataFrame(data={'A': a.flatten(), 'B': b.flatten(), 'C': c.flatten(), 'W': w.flatten(),'Wa': w.flatten()})
     return df0,a,b,c,w

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -32,6 +32,7 @@ df.eval("Bool=A>0.5", inplace=True)
 df.eval("BoolB=B>0.5", inplace=True)
 df.eval("BoolC=C>0.1", inplace=True)
 df["A"]=df["A"].round(3);
+df["A"][15] = math.nan
 df["B"]=df["B"].round(3);
 df["C"]=df["C"].round(3);
 df["D"]=df["D"].round(3);

--- a/RootInteractive/Tools/compressArray.py
+++ b/RootInteractive/Tools/compressArray.py
@@ -30,10 +30,12 @@ def roundRelativeBinary(df, nBits):
     type=df.dtype
     shiftN = 2 ** nBits
     mantissa, exp2 = np.frexp(df)
-    mantissa = ((mantissa * shiftN)+0.5).astype("int")
+    mantissa = ((mantissa * shiftN)+0.5)
+    mantissa = np.where(np.isnan(mantissa), 0, mantissa).astype("int")
     #mantissa = (mantissa * shiftN).rint()
-    mantissa /= shiftN
+    mantissa >>= nBits
     result=(mantissa * 2 ** exp2.astype(float)).astype(type)
+    result=df.where(df.notna(), result)
     return result
 
 
@@ -129,7 +131,7 @@ def compressArray(inputArray, actionArray, keepValues=False):
     currentArray = inputArray
     counter=0
     for action, actionParam in actionArray:
-        try:
+       # try:
             if keepValues:
                 arrayInfo["history"].append(currentArray)
             if action == "relative":
@@ -163,11 +165,11 @@ def compressArray(inputArray, actionArray, keepValues=False):
                         currentArray = currentArray.map(dictValues).astype("int32")
                         arrayInfo["indexType"] = "int32"
             if action == "decode":
-                arrayAsPanda=pdMap.DataFrame(currentArray)[0]       # TODO - numpy does not have map function better solution to fine
+                arrayAsPanda=pdMap.Series(currentArray)      # TODO - numpy does not have map function better solution to fine
                 currentArray = arrayAsPanda.map(arrayInfo["valueCode"])
             counter+=1
-        except:
-            print("compressArray - Unexpected error in ", action,  sys.exc_info()[0])
+       # except:
+        #    print("compressArray - Unexpected error in ", action,  sys.exc_info()[0])
             #pass
     arrayInfo["array"] = currentArray
     return arrayInfo


### PR DESCRIPTION
Relates to #137

This should fix two bugs in compressArray, one of them being an error handling bug that made the pipeline eat errors and continue with the array in a garbage state, the other bug was causing NaN values to crash when compression was used with used with "relative"