### PR TITLE
Layout bokeh

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -423,6 +423,32 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         widget_rows.js_on_change("value", CustomJS(args={"grid_inner": gridInner}, code=layout_widget_row_callback))
         if 'column_names' in options:
             widget_columns = MultiSelect(title="Show columns", value=optionsPlot, options=optionsPlot)
+            layout_widget_column_callback = \
+                """
+    console.log(this.value)
+    console.log(this.options)
+    console.log(grid_inner.children)
+    let j = 0
+    const l = this.value.length
+    const rows = grid_inner.children
+    const n_rows = rows.length
+    const n_columns = this.options.length
+    for(let i_row=0; i<n_rows; i_row++){
+        columns = rows[i_row].children
+        for(let i; i<n_columns; i++){
+            if (j === l){
+                columns[i].visible = false
+            } else if(this.options[i] == this.value[j]){
+                console.log(i)
+                console.log(j)
+                columns[i].visible = true
+                j++
+            } else {
+                columns[i].visible = false
+            }
+        }
+    }
+                """
             layout_widgets = row([widget_rows, widget_columns], sizing_mode=options['sizing_mode'])
         else:
             layout_widgets = row([widget_rows], sizing_mode=options['sizing_mode'])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -341,6 +341,11 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
     widgetRows = []
     row_names = []
     nRows = len(widgetArray)
+    same_size = True
+    rowWidget = widgetLayoutDesc[0]
+    if isinstance(rowWidget[-1], dict):
+        rowWidget = rowWidget[0:-1]
+    nColumns = len(rowWidget)
     # get/apply global options if exist
     if isinstance(widgetLayoutDesc[-1], dict):
         nRows -= 1
@@ -354,6 +359,8 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         if isinstance(rowWidget[-1], dict):
             rowOptions.update(rowWidget[-1])
             rowWidget = rowWidget[0:-1]
+        if nColumns != len(rowWidget):
+            same_size = False
         rowWidgetArray0 = []
         for i, iWidget in enumerate(rowWidget):
             figure = widgetArray[iWidget]
@@ -416,8 +423,13 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
     }
             """
         widget_rows.js_on_change("value", CustomJS(args={"grid_inner": gridInner}, code=layout_widget_row_callback))
-        if 'column_names' in options:
-            widget_columns = MultiSelect(title="Show columns", value=options['column_names'], options=options['column_names'])
+        if same_size:
+            column_names = []
+            for i in range(nColumns):
+                column_names.append(str(i))
+            if 'column_names' in options:
+                column_names = options['column_names']
+            widget_columns = MultiSelect(title="Show columns", value=column_names, options=column_names)
             layout_widget_column_callback = \
                 """
     let j = 0

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -894,13 +894,6 @@ def addHisto2dGlyph(fig, x, y, histoHandle, colorMapperDict, color, marker, dfQu
                           fill_color=mapperC)
         histoGlyphRenderer = fig.add_glyph(cdsHisto, histoGlyph)
         fig.add_layout(color_bar, 'right')
-        tooltips = None
-        if "tooltips" in histoHandle:
-            tooltips = histoHandle["tooltips"]
-        elif "tooltips" in options:
-            tooltips = options["histoTooltips"]
-        visualization_type = "points"
-        histoGlyphRenderer = None
 
     elif visualization_type == "colZ":
         mapperC = linear_cmap(field_name="bin_center_1", palette=options['palette'], low=min(dfQuery[y]),

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -400,9 +400,6 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         widget_rows = MultiSelect(title="Show rows", value=row_names, options=row_names)
         layout_widget_row_callback = \
             """
-    console.log(this.value)
-    console.log(this.options)
-    console.log(grid_inner.children)
     let j = 0
     const l = this.value.length
     const rows = grid_inner.children
@@ -411,8 +408,6 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         if (j === l){
             rows[i].visible = false
         } else if(this.options[i] == this.value[j]){
-            console.log(i)
-            console.log(j)
             rows[i].visible = true
             j++
         } else {
@@ -422,25 +417,21 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
             """
         widget_rows.js_on_change("value", CustomJS(args={"grid_inner": gridInner}, code=layout_widget_row_callback))
         if 'column_names' in options:
-            widget_columns = MultiSelect(title="Show columns", value=optionsPlot, options=optionsPlot)
+            widget_columns = MultiSelect(title="Show columns", value=options['column_names'], options=options['column_names'])
             layout_widget_column_callback = \
                 """
-    console.log(this.value)
-    console.log(this.options)
-    console.log(grid_inner.children)
     let j = 0
     const l = this.value.length
     const rows = grid_inner.children
     const n_rows = rows.length
     const n_columns = this.options.length
-    for(let i_row=0; i<n_rows; i_row++){
-        columns = rows[i_row].children
-        for(let i; i<n_columns; i++){
+    for(let i_row=0; i_row<n_rows; i_row++){
+        const columns = rows[i_row].children
+        j = 0
+        for(let i = 0; i<n_columns; i++){
             if (j === l){
                 columns[i].visible = false
             } else if(this.options[i] == this.value[j]){
-                console.log(i)
-                console.log(j)
                 columns[i].visible = true
                 j++
             } else {
@@ -449,6 +440,7 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         }
     }
                 """
+            widget_columns.js_on_change("value", CustomJS(args={"grid_inner": gridInner}, code=layout_widget_column_callback))
             layout_widgets = row([widget_rows, widget_columns], sizing_mode=options['sizing_mode'])
         else:
             layout_widgets = row([widget_rows], sizing_mode=options['sizing_mode'])

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -80,7 +80,7 @@ widgetLayoutDesc=[[0, 1, 2], [3, 4, 5], [6, 7],[8,9], {'sizing_mode': 'scale_wid
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
     [3, 4, 5, {'plot_height': 100, 'x_visible': 1, 'y_visible': 2}],
-    {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, 'column_names': ["3D", "markers", "yolo"], 'layout_widgets': True}
+    {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, 'layout_widgets': True}
 ]
 
 
@@ -88,10 +88,18 @@ def testBokehDrawArrayWidget():
     output_file("test_BokehDrawArrayWidget.html")
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode="scale_width")
 
+def testBokehDrawArrayWidgetInconsistentColumns():
+    output_file("test_BokehDrawArrayWidgetInconsistentColumns.html")
+    figureLayoutDesc = [
+        [0, 1, 2],
+        [3, 4, {'plot_height': 100, 'x_visible': 1, 'y_visible': 2}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible': 2, 'layout_widgets': True}
+    ]
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode="scale_width")
+
 def testBokehDrawArrayWidgetNoScale():
     output_file("test_BokehDrawArrayWidgetNoScale.html")
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None)
-
 
 def testBokehDrawArrayDownsample():
     output_file("test_BokehDrawArrayDownsample.html")

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -53,9 +53,10 @@ figureArray = [
     [['A'], ['C+A', 'C-A', 'A/A']],
     [['B'], ['C+B', 'C-B'], { "size": 7, "colorZvar": "EE", "errY": "errY", "rescaleColorMapper": True }],
     [['D'], ['(A+B+C)*D'], {"size": 10, "errY": "errY"} ],
-#    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
+    #[['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
     [['D'], ['D*10'], {"size": 10, "errY": "errY"}],
+    [['D'], ['D*D'], {"size": 10, "errY": "errY"}],
 ]
 #widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1), multiselect.E(0,1,2,3,4)"
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"
@@ -78,8 +79,8 @@ widgetLayoutDesc=[[0, 1, 2], [3, 4, 5], [6, 7],[8,9], {'sizing_mode': 'scale_wid
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
-    [3, 4, {'plot_height': 100, 'x_visible': 1, 'y_visible': 2}],
-    {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
+    [3, 4, 5, {'plot_height': 100, 'x_visible': 1, 'y_visible': 2}],
+    {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, 'column_names': ["3D", "markers", "yolo"], 'layout_widgets': True}
 ]
 
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -95,12 +95,12 @@ def testBokehDrawArrayWidgetNoScale():
 
 def testBokehDrawArrayDownsample():
     output_file("test_BokehDrawArrayDownsample.html")
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200)
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=200)
 
 def testBokehDrawArrayQuery():
     output_file("test_BokehDrawArrayQuery.html")
     df0 = df.copy()
-    xxx=bokehDrawSA.fromArray(df0, "BoolC == True", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200)
+    xxx=bokehDrawSA.fromArray(df0, "BoolC == True", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=200)
     assert (df0.keys() == df.keys()).all()
 
 def testBokehDrawArraySA_tree():


### PR DESCRIPTION
This PR adds more options to the "layout" and also technically the "widgetLayout" options in bokehDrawSA.
Relates to #142 

Options:
`layout_widgets`: Boolean, default False
Adds a MultiSelect widget that enables and disables the rows (and if possible also columns) in the layout
`row_names`, `column_names`: String, default None
Labels for the rows and columns in the MultiSelect widgets