### PR TITLE
Migration to bokeh 2.3.3

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
@@ -14,5 +14,5 @@ class CDSAlias(ColumnarDataSource):
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
     source=Instance(ColumnarDataSource, help="The source to draw from")
     mapping=Dict(String, Any, help="The mapping from new columns to old columns and possibly mappers")
-    includeOrigColumns=Bool
+    includeOrigColumns=Bool()
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
@@ -1,6 +1,11 @@
 from bokeh.core.properties import Instance, String, Float, Int, List, Dict, Any
 from bokeh.models import ColumnarDataSource
 
+try:
+    from bokeh.core.properties import Nullable
+    nullable_available = True
+except ImportError:
+    nullable_available = False
 
 class HistoNdCDS(ColumnarDataSource):
 
@@ -16,13 +21,19 @@ class HistoNdCDS(ColumnarDataSource):
 
     source = Instance(ColumnarDataSource, help="Source from which to take the data to histogram")
     sample_variables = List(String, help="Names of the columns used for binning")
-    weights = String(default=None)
     # TODO: Support auto nbins in the future - 2n-th root of total entries?
     nbins = List(Int, help="Number of bins")
-    # TODO: When migrating to new version of bokeh, make this Nullable
-    range = List(List(Float), help="Ranges in the same order as sample_variables")
-    # TODO: Make this nullable too
-    histograms = Dict(String, Dict(String, Any), default={"entries": {}}, help="""
-    Dictionary of the values to histogram.
-    Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
-        """)
+    if nullable_available:
+        range = Nullable(List(Nullable((List(Float)))), help="Ranges in the same order as sample_variables")
+        weights = Nullable(String(), default=None)
+        histograms = Nullable(Dict(String, Dict(String, Any)), default={"entries": {}}, help="""
+        Dictionary of the values to histogram.
+        Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
+            """)
+    else:
+        range = List(List(Float), help="Ranges in the same order as sample_variables")
+        weights = String(default=None)
+        histograms = Dict(String, Dict(String, Any), default={"entries": {}}, help="""
+        Dictionary of the values to histogram.
+        Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
+            """)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
@@ -26,7 +26,7 @@ class HistoNdCDS(ColumnarDataSource):
     if nullable_available:
         range = Nullable(List(Nullable((List(Float)))), help="Ranges in the same order as sample_variables")
         weights = Nullable(String(), default=None)
-        histograms = Nullable(Dict(String, Dict(String, Any)), default={"entries": {}}, help="""
+        histograms = Nullable(Dict(String, Nullable(Dict(String, Any))), default={"entries": {}}, help="""
         Dictionary of the values to histogram.
         Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
             """)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
@@ -26,14 +26,14 @@ class HistoNdCDS(ColumnarDataSource):
     if nullable_available:
         range = Nullable(List(Nullable((List(Float)))), help="Ranges in the same order as sample_variables")
         weights = Nullable(String(), default=None)
-        histograms = Nullable(Dict(String, Nullable(Dict(String, Any))), default={"entries": {}}, help="""
+        histograms = Nullable(Dict(String, Nullable(Dict(String, Any))), help="""
         Dictionary of the values to histogram.
         Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
             """)
     else:
         range = List(List(Float), help="Ranges in the same order as sample_variables")
         weights = String(default=None)
-        histograms = Dict(String, Dict(String, Any), default={"entries": {}}, help="""
+        histograms = Dict(String, Dict(String, Any), help="""
         Dictionary of the values to histogram.
         Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
             """)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
@@ -26,7 +26,7 @@ class HistoNdCDS(ColumnarDataSource):
     if nullable_available:
         range = Nullable(List(Nullable((List(Float)))), help="Ranges in the same order as sample_variables")
         weights = Nullable(String(), default=None)
-        histograms = Nullable(Dict(String, Nullable(Dict(String, Any))), help="""
+        histograms = Dict(String, Nullable(Dict(String, Any)), default={}, help="""
         Dictionary of the values to histogram.
         Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
             """)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -35,14 +35,14 @@ export class HistoNdCDS extends ColumnarDataSource {
 
   static init_HistoNdCDS() {
 
-    this.define<HistoNdCDS.Props>(({Ref, Array, Nullable, Number, Int, String, Dict, Any})=>({
+    this.define<HistoNdCDS.Props>(({Ref, Array, Nullable, Number, Int, String, Any})=>({
       source:  [Ref(ColumnarDataSource)],
 //      view:         [Nullable(Array(Int)), null], - specifying this as a bokeh property causes a drastic drop in performance
       nbins:        [Array(Int)],
       range:    [Nullable(Array(Nullable(Array(Number))))],
       sample_variables:      [Array(String)],
       weights:      [Nullable(String), null],
-      histograms:  [Dict(Any), {}]
+      histograms:  [Any, {}]
     }))
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -35,14 +35,14 @@ export class HistoNdCDS extends ColumnarDataSource {
 
   static init_HistoNdCDS() {
 
-    this.define<HistoNdCDS.Props>(({Ref, Array, Nullable, Number, Int, String})=>({
+    this.define<HistoNdCDS.Props>(({Ref, Array, Nullable, Number, Int, String, Dict, Any})=>({
       source:  [Ref(ColumnarDataSource)],
 //      view:         [Nullable(Array(Int)), null], - specifying this as a bokeh property causes a drastic drop in performance
       nbins:        [Array(Int)],
       range:    [Nullable(Array(Nullable(Array(Number))))],
       sample_variables:      [Array(String)],
       weights:      [Nullable(String), null],
-      histograms:  [p.Instance]
+      histograms:  [Dict(Any), {}]
     }))
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -41,7 +41,7 @@ export class HistoNdCDS extends ColumnarDataSource {
       nbins:        [Array(Int)],
       range:    [Nullable(Array(Nullable(Array(Number))))],
       sample_variables:      [Array(String)],
-      weights:      [String, null],
+      weights:      [Nullable(String), null],
       histograms:  [p.Instance]
     }))
   }
@@ -87,7 +87,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     this._nbins = this.nbins;
 
     let sample_array: ArrayLike<number>[] = []
-    if(this.range === null || this.range.reduce((acc, cur) => acc || (cur === null), false))
+    if(this.range === null || this.range.reduce((acc: boolean, cur) => acc || (cur === null), false))
     for (const column_name of this.sample_variables) {
       const column = this.source.get_column(column_name)
       if (column == null){

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.py
@@ -16,6 +16,6 @@ class HistoNdProfile(ColumnarDataSource):
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
 
     source = Instance(HistoNdCDS)
-    axis_idx = Int
+    axis_idx = Int(default=0)
     quantiles = List(Float)
     sum_range = List(List(Float))

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -30,7 +30,7 @@ export class HistoNdProfile extends ColumnarDataSource {
 
     this.define<HistoNdProfile.Props>(({Ref, Array, Number, Int})=>({
       source:  [Ref(HistoNdCDS)],
-      axis_idx: [Int],
+      axis_idx: [Int, 0],
       quantiles: [Array(Number), []], // This is the list of all quantiles to compute, length is NOT equal to CDS length
       sum_range: [Array(Array(Number)), []]
     }))

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoStatsCDS.py
@@ -18,7 +18,7 @@ class HistoStatsCDS(ColumnarDataSource):
     names = List(String)
     bin_centers = List(String)
     bincount_columns = List(String)
-    rowwise = Bool
+    rowwise = Bool()
     quantiles = List(Float)
     compute_quantile = List(Bool)
     edges_left = List(String)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
@@ -1,6 +1,11 @@
 from bokeh.core.properties import Instance, String, Float, Int, List, Dict, Any
 from bokeh.models import ColumnarDataSource
 
+try:
+    from bokeh.core.properties import Nullable
+    nullable_available = True
+except ImportError:
+    nullable_available = False
 
 class HistogramCDS(ColumnarDataSource):
 
@@ -17,9 +22,13 @@ class HistogramCDS(ColumnarDataSource):
     source = Instance(ColumnarDataSource, help="Source from which to take the data to histogram")
     view = List(Int)
     sample = String()
-    weights = String(default=None)
+    if nullable_available:
+        weights = Nullable(String(), default=None)
+        range = Nullable(List(Float))
+    else:
+        weights = String(default=None)
+        range = List(Float)
     nbins = Int()
-    range = List(Float)
     histograms = Dict(String, Dict(String, Any), default={"entries": {}}, help="""
     Dictionary of the values to histogram.
     Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
@@ -25,7 +25,7 @@ class HistogramCDS(ColumnarDataSource):
     if nullable_available:
         weights = Nullable(String(), default=None)
         range = Nullable(List(Float))
-        histograms = Dict(String, Nullable(Dict(String, Any)), help="""
+        histograms = Dict(String, Nullable(Dict(String, Any)), default={}, help="""
             Dictionary of the values to histogram.
             Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
         """)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.py
@@ -25,12 +25,17 @@ class HistogramCDS(ColumnarDataSource):
     if nullable_available:
         weights = Nullable(String(), default=None)
         range = Nullable(List(Float))
+        histograms = Dict(String, Nullable(Dict(String, Any)), help="""
+            Dictionary of the values to histogram.
+            Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
+        """)
     else:
         weights = String(default=None)
         range = List(Float)
+        histograms = Dict(String, Dict(String, Any), help="""
+            Dictionary of the values to histogram.
+            Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
+        """)
     nbins = Int()
-    histograms = Dict(String, Dict(String, Any), default={"entries": {}}, help="""
-    Dictionary of the values to histogram.
-    Keys are the names of the resulting columns, values are dictionaries with the only option supported being weights, the value of which is the column name with weights.
-    """)
+
     print("x", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -12,7 +12,7 @@ export namespace HistogramCDS {
     range:    p.Property<number[] | null>
     sample:      p.Property<string>
     weights:      p.Property<string | null>
-    histograms: p.Property<Record<string, Record<string, any>>>
+    histograms: p.Property<Record<string, Record<string, any> | null>>
   }
 }
 
@@ -29,14 +29,14 @@ export class HistogramCDS extends ColumnarDataSource {
 
   static init_HistogramCDS() {
 
-    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable, String, Dict, Any})=>({
+    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable, String, Any})=>({
       source:  [Ref(ColumnDataSource)],
 //      view:         [Nullable(Array(Int)), null],
       nbins:        [Number],
       range:    [Nullable(Array(Number))],
       sample:      [String],
       weights:      [Nullable(String), null],
-      histograms:  [Dict(Any), {}]
+      histograms:  [Any, {}]
     }))
   }
 
@@ -247,7 +247,7 @@ export class HistogramCDS extends ColumnarDataSource {
       if(histograms[key] == null){
         data[key] = this.histogram(null)
       } else {
-        data[key] = this.histogram(histograms[key].weights)
+        data[key] = this.histogram(histograms[key]!.weights)
       }
     } 
   }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -29,14 +29,14 @@ export class HistogramCDS extends ColumnarDataSource {
 
   static init_HistogramCDS() {
 
-    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable, String})=>({
+    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable, String, Dict, Any})=>({
       source:  [Ref(ColumnDataSource)],
 //      view:         [Nullable(Array(Int)), null],
       nbins:        [Number],
       range:    [Nullable(Array(Number))],
       sample:      [String],
       weights:      [Nullable(String), null],
-      histograms:  [p.Instance]
+      histograms:  [Dict(Any), {}]
     }))
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -29,13 +29,13 @@ export class HistogramCDS extends ColumnarDataSource {
 
   static init_HistogramCDS() {
 
-    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable})=>({
+    this.define<HistogramCDS.Props>(({Ref, Number, Array, Nullable, String})=>({
       source:  [Ref(ColumnDataSource)],
 //      view:         [Nullable(Array(Int)), null],
       nbins:        [Number],
       range:    [Nullable(Array(Number))],
-      sample:      [p.String],
-      weights:      [p.String, null],
+      sample:      [String],
+      weights:      [Nullable(String), null],
       histograms:  [p.Instance]
     }))
   }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.py
@@ -30,9 +30,9 @@ class BokehVisJSGraph3D(LayoutDOM):
     # The data will actually be stored in the ColumnDataSource, but these
     # properties let us specify the *name* of the column that should be
     # used for each field.
-    x = String
-    y = String
-    z = String
-    style = String
+    x = String()
+    y = String()
+    z = String()
+    style = String()
     options3D = Dict(String, Any)
     print("x", __implementation__)


### PR DESCRIPTION
This PR introduces back-compatibility breaking changes that allow migration to bokeh 2.4.1 as of today the newest version. It also changes the requirements.txt and setup.py files to reflect that change.

The migration to a new version of bokeh seems to have resulted in better performance, changing the selection in test_bokehClientHistogramWeight got reduced from 200ms to 150ms on my machine. Other clientside benchmarks to be tested soon.

EDIT: Seems that it still works with bokeh 2.3.0, doesn't work with previous versions of bokeh