### PR TITLE
Color Z widget

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -141,32 +141,52 @@ export class HistoNdCDS extends ColumnarDataSource {
     if(this.range === null || this.range.reduce((acc, cur) => acc || (cur === null), false))
     for (const column_name of this.sample_variables) {
       const column = this.source.get_array(column_name) as number[]
-      if (this.view === null){
-        sample_array.push(column)
-      } else {
-        sample_array.push(this.view.map((val: number) => column[val]))
-      }
+      sample_array.push(column)
     }
       // This code seems stupid
       let invalidate_bins = false
-      if(this.range === null){
-        for (let i = 0; i < this._nbins.length; i++) {
-          this._range_min[i] = sample_array[i].reduce((acc, cur) => Math.min(acc, cur), Infinity)
-          this._range_max[i] = sample_array[i].reduce((acc, cur) => Math.max(acc, cur), -Infinity)
-        }
-        invalidate_bins = true
-      } else {
-        for (let i = 0; i < this.range.length; i++) {
-          const r = this.range[i]
-          if(r === null) {
+      if(this.view === null){
+        if(this.range === null){
+          for (let i = 0; i < this._nbins.length; i++) {
             this._range_min[i] = sample_array[i].reduce((acc, cur) => Math.min(acc, cur), Infinity)
             this._range_max[i] = sample_array[i].reduce((acc, cur) => Math.max(acc, cur), -Infinity)
-            invalidate_bins = true
-          } else {
-            this._range_min[i] = r[0]
-            this._range_max[i] = r[1]
+          }
+          invalidate_bins = true
+        } else {
+          for (let i = 0; i < this.range.length; i++) {
+            const r = this.range[i]
+            if(r === null) {
+              this._range_min[i] = sample_array[i].reduce((acc, cur) => Math.min(acc, cur), Infinity)
+              this._range_max[i] = sample_array[i].reduce((acc, cur) => Math.max(acc, cur), -Infinity)
+              invalidate_bins = true
+            } else {
+              this._range_min[i] = r[0]
+              this._range_max[i] = r[1]
+            }
           }
         }
+      } else {
+        if(this.range === null){
+          for (let i = 0; i < this._nbins.length; i++) {
+            const col = sample_array[i]
+            this._range_min[i] = this.view.reduce((acc, cur) => Math.min(acc, col[cur]), Infinity)
+            this._range_max[i] = this.view.reduce((acc, cur) => Math.max(acc, col[cur]), -Infinity)
+          }
+          invalidate_bins = true
+        } else {
+          for (let i = 0; i < this.range.length; i++) {
+            const r = this.range[i]
+            if(r === null) {
+              const col = sample_array[i]
+              this._range_min[i] = this.view.reduce((acc, cur) => Math.min(acc, col[cur]), Infinity)
+              this._range_max[i] = this.view.reduce((acc, cur) => Math.max(acc, col[cur]), -Infinity)
+              invalidate_bins = true
+            } else {
+              this._range_min[i] = r[0]
+              this._range_max[i] = r[1]
+            }
+          }
+        }        
       }
       if (invalidate_bins || this._bin_indices.length === 0){
         this._bin_indices.length = this.source.length

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -93,6 +93,7 @@ class bokehDrawSA(object):
         self.histoList = None
         self.cdsHistoSummary = None
         self.profileList = None
+        self.paramDict = None
 
     @classmethod
     def fromArray(cls, dataFrame, query, figureArray, widgetsDescription, **kwargs):
@@ -159,7 +160,7 @@ class bokehDrawSA(object):
         kwargs["optionList"]=optionList
         self = cls(dataFrame, query, "", "", "", "", None, variables=varList, **kwargs)
         dfQuery, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"],
-                                              widgetArray=widgetsDescription, options={"removeExtraColumns": True})
+                                              widgetArray=widgetsDescription, paremeterArray=options["parameterArray"], options={"removeExtraColumns": True})
         self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapDict, self.cdsOrig, self.histoList,\
             self.cdsHistoSummary, self.profileList = bokehDrawArray(dfQuery, None, figureArray, removeExtraColumns=False, **kwargs)
         # self.cdsOrig=ColumnDataSource(dataFrameOrig)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -186,7 +186,7 @@ class bokehDrawSA(object):
         if type(widgetsDescription)==list:
             widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList,
                                          self.cmapList, self.cdsHistoSummary, self.profileList, self.paramDict, nPointRender = self.options['nPointRender'])
-            if isinstance(self.widgetLayout, list):
+            if isinstance(self.widgetLayout, list) or isinstance(self.widgetLayout, dict):
                 widgetList=processBokehLayoutArray(self.widgetLayout, widgetList)
             else:
                 widgetList=column(widgetList)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -131,7 +131,8 @@ class bokehDrawSA(object):
         """
         options={
             'nPointRender': 10000,
-            "histogramArray": []
+            "histogramArray": [],
+            'parameterArray': []
         }
         options.update(kwargs)
         kwargs=options

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -159,10 +159,10 @@ class bokehDrawSA(object):
                 varList+=w[1][0]+":"
         kwargs["optionList"]=optionList
         self = cls(dataFrame, query, "", "", "", "", None, variables=varList, **kwargs)
-        dfQuery, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"],
-                                              widgetArray=widgetsDescription, paremeterArray=options["parameterArray"], options={"removeExtraColumns": True})
+        dfQuery, _, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"],
+                                              widgetArray=widgetsDescription, parameterArray=options["parameterArray"], options={"removeExtraColumns": True})
         self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapDict, self.cdsOrig, self.histoList,\
-            self.cdsHistoSummary, self.profileList = bokehDrawArray(dfQuery, None, figureArray, removeExtraColumns=False, **kwargs)
+            self.cdsHistoSummary, self.profileList, self.paramDict = bokehDrawArray(dfQuery, None, figureArray, removeExtraColumns=False, **kwargs)
         # self.cdsOrig=ColumnDataSource(dataFrameOrig)
         #self.Widgets = self.initWidgets(widgetString)
         widgetList=self.initWidgets(widgetsDescription)
@@ -184,7 +184,7 @@ class bokehDrawSA(object):
         """
         if type(widgetsDescription)==list:
             widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList,
-                                         self.cmapDict, self.cdsHistoSummary, self.profileList, nPointRender = self.options['nPointRender'])
+                                         self.cmapDict, self.cdsHistoSummary, self.profileList, self.paramDict, nPointRender = self.options['nPointRender'])
             if isinstance(self.widgetLayout, list):
                 widgetList=processBokehLayoutArray(self.widgetLayout, widgetList)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -89,7 +89,7 @@ class bokehDrawSA(object):
         self.plotArray.append(self.initWidgets(widgetsDescription))
         self.pAll=gridplotRow(self.plotArray)
         self.handle=show(self.pAll,notebook_handle=self.isNotebook)
-        self.cmapDist = None
+        self.cmapList = None
         self.histoList = None
         self.cdsHistoSummary = None
         self.profileList = None
@@ -161,7 +161,7 @@ class bokehDrawSA(object):
         self = cls(dataFrame, query, "", "", "", "", None, variables=varList, **kwargs)
         dfQuery, _, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"],
                                               widgetArray=widgetsDescription, parameterArray=options["parameterArray"], options={"removeExtraColumns": True})
-        self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapDict, self.cdsOrig, self.histoList,\
+        self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapList, self.cdsOrig, self.histoList,\
             self.cdsHistoSummary, self.profileList, self.paramDict = bokehDrawArray(dfQuery, None, figureArray, removeExtraColumns=False, **kwargs)
         # self.cdsOrig=ColumnDataSource(dataFrameOrig)
         #self.Widgets = self.initWidgets(widgetString)
@@ -184,7 +184,7 @@ class bokehDrawSA(object):
         """
         if type(widgetsDescription)==list:
             widgetList= makeBokehWidgets(self.dataSource, widgetsDescription, self.cdsOrig, self.cdsSel, self.histoList,
-                                         self.cmapDict, self.cdsHistoSummary, self.profileList, self.paramDict, nPointRender = self.options['nPointRender'])
+                                         self.cmapList, self.cdsHistoSummary, self.profileList, self.paramDict, nPointRender = self.options['nPointRender'])
             if isinstance(self.widgetLayout, list):
                 widgetList=processBokehLayoutArray(self.widgetLayout, widgetList)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -712,6 +712,15 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             cds_used = source
             if cmap_cds_name is not None:
                 cds_used = cdsDict[cmap_cds_name]
+                if cmap_cds_name in histogramDict and histogramDict[cmap_cds_name]['type'] == 'profile' and varColor.split('_')[0] == 'bin':
+                    histogramDict[cmap_cds_name]['cds'].js_on_change('change', CustomJS(code="""
+                    const col = this.data[field]
+                    const isOK = this.data.isOK
+                    const low = col.map((x,i) => isOK[i] ? col[i] : Infinity).reduce((acc, cur)=>Math.min(acc,cur), Infinity);
+                    const high = col.map((x,i) => isOK[i] ? col[i] : -Infinity).reduce((acc, cur)=>Math.max(acc,cur), -Infinity);
+                    cmap.high = high;
+                    cmap.low = low;
+                    """, args={"field": mapperC["field"], "cmap": mapperC["transform"]})) 
             axis_title = getHistogramAxisTitle(histogramDict, varColor, cmap_cds_name)
             color_bar = ColorBar(color_mapper=mapperC['transform'], width=8, location=(0, 0), title=axis_title)
             if optionLocal['colorZvar'] in paramDict:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1259,8 +1259,8 @@ def bokehMakeParameters(parameterArray, histogramArray, figureArray, variableLis
     parameterDict = {}
     if parameterArray is not None:
         for param in parameterArray:
-            param["subscribed_events"] = []
             parameterDict[param["name"]] = param.copy()
+            parameterDict[param["name"]]["subscribed_events"] = []
     if histogramArray is not None:
         for iHisto in histogramArray: 
             pass

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -769,13 +769,13 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     y_label = getHistogramAxisTitle(histogramDict, varNameY, cds_name)
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_label=y_label + " vs " + x_label)
-                  #  if optionLocal["colorZvar"] in paramDict:
-                   #     paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
+                    if optionLocal["colorZvar"] in paramDict:
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
                 else:
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_field=optionLocal["legend_field"])
-                   # if optionLocal["colorZvar"] in paramDict:
-                   #     paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
+                    if optionLocal["colorZvar"] in paramDict:
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
                 defaultHoverToolRenderers.append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
                     errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)
@@ -1086,9 +1086,6 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                 for i in axisIndices:
                     cdsProfile = HistoNdProfile(source=cdsHisto, axis_idx=i, quantiles=optionLocal["quantiles"],
                                                 sum_range=optionLocal["sum_range"])
-                    isOkFilter = BooleanFilter()
-                    cdsProfile.js_on_change('change', CustomJS(code="filter.booleans = this.data.isOK", args={"filter": isOkFilter}))
-                    projectionView = CDSView(source=cdsProfile, filters=[isOkFilter])
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
                     "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "view": projectionView}
@@ -1109,9 +1106,6 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                 for i in axisIndices:
                     cdsProfile = HistoNdProfile(source=cdsHisto, axis_idx=i, quantiles=optionLocal["quantiles"],
                                                 sum_range=optionLocal["sum_range"])
-                    isOkFilter = BooleanFilter()
-                    projectionView = CDSView(source=cdsProfile, filters=[isOkFilter])
-                    cdsProfile.js_on_change('change', CustomJS(code="filter.booleans = this.data.isOK", args={"filter": isOkFilter}))
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
                     "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "view": projectionView} 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,6 +1,6 @@
 from io import UnsupportedOperation
 from bokeh.plotting import figure, show, output_file
-from bokeh.models import ColumnDataSource, ColorBar, HoverTool, CDSView, BooleanFilter, VBar, HBar, Quad, Image
+from bokeh.models import ColumnDataSource, ColorBar, HoverTool, VBar, HBar, Quad
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.models.widgets.tables import ScientificFormatter, DataTable
 from bokeh.transform import *

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -764,24 +764,32 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 #                zAxisTitle +=varColor + ","
                 #            view = CDSView(source=source, filters=[GroupFilter(column_name=optionLocal['filter'], group=True)])
                 drawnGlyph = None
+                colorMapperCallback = """
+                glyph.fill_color={field:this.value, transform:glyph.fill_color.transform}
+                glyph.line_color={field:this.value, transform:glyph.line_color.transform}
+                """
                 if optionLocal["legend_field"] is None:
                     x_label = getHistogramAxisTitle(histogramDict, varNameX, cds_name)
                     y_label = getHistogramAxisTitle(histogramDict, varNameY, cds_name)
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_label=y_label + " vs " + x_label)
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code="console.log(this.value); glyph.fill_color={field:this.value, transform:glyph.fill_color.transform}")])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code=colorMapperCallback)])
                 else:
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_field=optionLocal["legend_field"])
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code="console.log(this.value); glyph.fill_color={field:this.value, transform:glyph.fill_color.transform}")])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code=colorMapperCallback)])
                 defaultHoverToolRenderers.append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
                     errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)
+                    if optionLocal["colorZvar"] in paramDict:
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": errorX}, code=colorMapperCallback)])
                     figureI.add_glyph(source, errorX)
                 if ('errY' in optionLocal.keys()) and (optionLocal['errY'] != '') and (cds_name is None):
                     errorY = VBar(x=varNameX, width=0, bottom=varNameY+"_lower", top=varNameY+"_upper", line_color=color)
+                    if optionLocal["colorZvar"] in paramDict:
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": errorY}, code=colorMapperCallback)])
                     figureI.add_glyph(source, errorY)
                 #    errors = Band(base=varNameX, lower=varNameY+"_lower", upper=varNameY+"_upper",source=source)
                 #    figureI.add_layout(errors)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1260,7 +1260,7 @@ def bokehMakeParameters(parameterArray, histogramArray, figureArray, variableLis
     if parameterArray is not None:
         for param in parameterArray:
             param["subscribed_events"] = []
-            parameterDict[param["name"]] = param
+            parameterDict[param["name"]] = param.copy()
     if histogramArray is not None:
         for iHisto in histogramArray: 
             pass

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -515,7 +515,7 @@ def makeBokehHistoTable(histoDict, rowwise=False, **kwargs):
     return stats_cds, data_table
 
 
-def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], **kwargs):
+def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterArray=[], **kwargs):
     """
     Wrapper bokeh draw array of figures
 
@@ -588,7 +588,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], **kwargs):
         dfQuery = dataFrame.copy()
     # Check/resp. load derived variables
     i: int
-    dfQuery, histogramDict, output_cdsSel, columnNameDict = makeDerivedColumns(dfQuery, figureArray, histogramArray=histogramArray, options=options)
+    dfQuery, histogramDict, output_cdsSel, columnNameDict, parameterDict = makeDerivedColumns(dfQuery, figureArray, histogramArray=histogramArray, paremeterArray=parameterArray, options=options)
 
     try:
         cdsFull = ColumnDataSource(dfQuery)
@@ -1067,7 +1067,7 @@ def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDi
     return widgetArray
 
 
-def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=None, **kwargs):
+def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=None, parameterDict={}, **kwargs):
     options = {"range": None,
                "nbins": 10,
                "weights": None,
@@ -1134,13 +1134,18 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
     return histoDict
 
 
-def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, widgetArray=None, options={}):
+def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameterArray=None, widgetArray=None, options={}):
     histogramDict = {}
     columnNameDict = {}
+    paramDict = {}
     output_cdsSel = False
     if histogramArray is not None:
         for i, histo in enumerate(histogramArray):
             histogramDict[histo["name"]] = True
+
+    if parameterArray is not None:
+          for i, param in enumerate(parameterArray):
+            paramDict[param["name"]] = True      
 
     if figureArray is not None:
         for i, variables in enumerate(figureArray):
@@ -1212,6 +1217,32 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, widgetArr
         dfQuery = dfQuery[columnNameDict]
 
     return dfQuery, histogramDict, output_cdsSel, columnNameDict
+
+def bokehMakeParameters(parameterArray, histogramArray, figureArray, options={}):
+    parameterDict = {}
+    if parameterArray is not None:
+        for param in parameterArray:
+            parameterDict[param["name"]] = param  
+    if histogramArray is not None:
+        for iHisto in histogramArray: 
+            pass
+    if figureArray is not None:
+        for i, variables in enumerate(figureArray):
+            if len(variables) > 1 and variables[0] != "table" and variables[0] != "tableHisto":
+                if len(variables) > 2:
+                    optionLocal = options.copy()
+                    optionLocal.update(variables[2])
+                else:
+                    optionLocal = options      
+                if 'colorZvar' in options:
+                    varColor = options['colorZvar']
+                    if varColor in parameterDict:
+                        paramColor = parameterDict[varColor]
+                        # Possibly also allow custom color mappers?
+                        paramColor["value"] = 
+
+
+    return parameterDict
 
 def getOrMakeColumn(dfQuery, column, cdsName):
     if '.' in column:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -952,12 +952,15 @@ def makeBokehSliderWidget(df, isRange, params, **kwargs):
     return slider
 
 
-def makeBokehSelectWidget(df, params, **kwargs):
+def makeBokehSelectWidget(df, params, paramDict, **kwargs):
     options = {'default': 0, 'size': 10}
     options.update(kwargs)
     # optionsPlot = []
     if len(params) == 1:
-        optionsPlot = np.sort(df[params[0]].unique()).tolist()
+        if options['callback'] == 'parameter':
+            optionsPlot = paramDict[params[0]]["options"]
+        else:
+            optionsPlot = np.sort(df[params[0]].unique()).tolist()
     else:
         optionsPlot = params[1:]
     for i, val in enumerate(optionsPlot):
@@ -1014,7 +1017,7 @@ def makeBokehWidgets(df, widgetParams, cdsOrig, cdsSel, histogramList=[], cmapDi
         if type == 'slider':
             localWidget = makeBokehSliderWidget(df, False, params, **optionLocal)
         if type == 'select':
-            localWidget = makeBokehSelectWidget(df, params, **optionLocal)
+            localWidget = makeBokehSelectWidget(df, params, paramDict, **optionLocal)
         if type == 'multiSelect':
             localWidget = makeBokehMultiSelectWidget(df, params, **optionLocal)
         # if type=='checkbox':
@@ -1157,8 +1160,11 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                             columnNameDict[varNameY] = True
                         if ('colorZvar' in optionLocal) and (optionLocal['colorZvar'] != '') and ('.' not in optionLocal['colorZvar']):
                             if optionLocal['colorZvar'] in paramDict:
-                                dfQuery, varNameZ = pandaGetOrMakeColumn(dfQuery, paramDict[optionLocal['colorZvar']]["value"])
-                                columnNameDict[varNameZ] = True
+                                parameter = paramDict[optionLocal['colorZvar']]
+                                if 'options' in parameter:
+                                    for i in parameter['options']:
+                                        dfQuery, varNameZ = pandaGetOrMakeColumn(dfQuery, i)
+                                        columnNameDict[varNameZ] = True
                             else:
                                 dfQuery, varNameZ = pandaGetOrMakeColumn(dfQuery, optionLocal['colorZvar'])
                                 columnNameDict[varNameZ] = True

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -770,12 +770,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_label=y_label + " vs " + x_label)
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"color": drawnGlyph.glyph.fill_color}, code="color={...color, field=this.value}")])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code="console.log(this.value); glyph.fill_color={field:this.value, transform:glyph.fill_color.transform}")])
                 else:
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_field=optionLocal["legend_field"])
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"color": drawnGlyph.glyph.fill_color}, code="color={...color, field=this.value}")])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": drawnGlyph.glyph}, code="console.log(this.value); glyph.fill_color={field:this.value, transform:glyph.fill_color.transform}")])
                 defaultHoverToolRenderers.append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
                     errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -496,6 +496,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
     :param dataFrame:         - input data frame
     :param query:             - query
     :param figureArray:       - figure array
+    :param histogramArray:    - (optional) histogram array
+    :param parameterArray:    - (optional) parameter array for parameters controllable on client
     :param kwargs:
     :return:
         variable list:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1099,7 +1099,7 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                                                 sum_range=optionLocal["sum_range"])
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
-                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "view": projectionView}
+                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"]}
                 histoDict[histoName]["profiles"] = profilesDict
         else:
             sampleVarNames = []
@@ -1119,7 +1119,7 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                                                 sum_range=optionLocal["sum_range"])
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
-                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "view": projectionView} 
+                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"]} 
                 histoDict[histoName]["profiles"] = profilesDict
 
     return histoDict

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -690,7 +690,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         cmap_cds_name = None
         if (len(optionLocal["colorZvar"]) > 0):
             #TODO: Support multiple color mappers, add more options, possibly use custom color mapper to improve performance
-            #So far, rescaleColorMapper is only supported for the main CDS
+            #So far, parametrized colZ is only supported for the main CDS
             logging.info("%s", optionLocal["colorZvar"])
             colorZVar = optionLocal['colorZvar']
             if colorZVar in paramDict:
@@ -770,12 +770,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_label=y_label + " vs " + x_label)
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"color": drawnGlyph.glyph.fill_color}, code="color={...color, field=this.value}")])
                 else:
                     drawnGlyph = figureI.scatter(x=varNameX, y=varNameY, fill_alpha=1, source=cds_used, size=optionLocal['size'],
                                 color=color, marker=marker, legend_field=optionLocal["legend_field"])
                     if optionLocal["colorZvar"] in paramDict:
-                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", drawnGlyph.glyph, "fill_color", "field"])
+                        paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"color": drawnGlyph.glyph.fill_color}, code="color={...color, field=this.value}")])
                 defaultHoverToolRenderers.append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
                     errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -315,6 +315,11 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray):
         {'width':10,'plot_height':200, 'sizing_mode':'scale_width'}
     ]
     """
+    if isinstance(widgetLayoutDesc, dict):
+        tabs = []
+        for i, iPanel in widgetLayoutDesc.items():
+            tabs.append(Panel(child=processBokehLayoutArray(iPanel, widgetArray), title=i))
+        return Tabs(tabs=tabs)
     options = {
         'commonX': -1, 'commonY': -1,
         'x_visible': 1, 'y_visible': 1,

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -712,13 +712,18 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 low = optionLocal["cmapLow"]
             if "cmapHigh" in optionLocal:
                 high = optionLocal["cmapHigh"]   
-            if optionLocal["rescaleColorMapper"] or optionLocal["colorZvar"] in paramDict:            
-                mapperC = {"field": varColor, "transform": LinearColorMapper(palette=optionLocal['palette'])}
+            if optionLocal["rescaleColorMapper"] or optionLocal["colorZvar"] in paramDict:
+                if optionLocal["colorZvar"] in colorMapperDict:
+                    mapperC = colorMapperDict[optionLocal["colorZvar"]]
+                else:
+                    mapperC = {"field": varColor, "transform": LinearColorMapper(palette=optionLocal['palette'])}
+                    colorMapperDict[optionLocal["colorZvar"]] = mapperC
             else:
                 mapperC = linear_cmap(field_name=varColor, palette=optionLocal['palette'], low=low, high=high)
             cds_used = source
             if cmap_cds_name is not None:
                 cds_used = cdsDict[cmap_cds_name]
+                # This is really hacky, will probably be removed when ND histogram joins start working
                 if cmap_cds_name in histogramDict and histogramDict[cmap_cds_name]['type'] == 'profile' and varColor.split('_')[0] == 'bin':
                     histogramDict[cmap_cds_name]['cds'].js_on_change('change', CustomJS(code="""
                     const col = this.data[field]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -32,16 +32,21 @@ widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1
 figureLayout: str = '((0,1,2, plot_height=300),commonX=1,plot_height=300,plot_width=1200)'
 tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)")]
 
+parameterArray=[
+    {'name':"size", "value":7, "range": [0, 20]}
+]
+
 widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1]],
     ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['multiSelect', ["DDC"]],
+    ['slider',["size"], {"callback": "parameter"}],
   #  ['select',["CC", 0, 1, 2, 3]],
   #  ['multiSelect',["BoolB"]],
 ]
-widgetLayoutDesc=[[0, 1, 2], [3, 4], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], {'sizing_mode': 'scale_width'}]
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -59,13 +64,13 @@ def testBokehClientHistogram():
     output_file("test_BokehClientHistogram.html")
     figureArray = [
         #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
-        [['A'], ['histoA', '(A*A-C*C)*100'], {"size": 2, "colorZvar": "A", "errY": "errY", "errX": "0.01"}],
+        [['A'], ['histoA', '(A*A-C*C)*100'], {"size": 2, "colorZvar": "A", "errY": "errY", "errX": "0.01", "size":"size"}],
         [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2",
-                                                            "rescaleColorMapper": True}],
+                                                            "rescaleColorMapper": True, "size":"size"}],
         [['B'], ['histoB', '(C+B)*10', '(C-B)*10'], {"size": 7, "colorZvar": "C", "errY": "errY",
-                                                    "rescaleColorMapper": True}]
+                                                    "rescaleColorMapper": True, "size":"size"}]
     ]
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=300, histogramArray=histoArray)
 
 def testBokehClientHistogramOnlyHisto():
@@ -83,16 +88,16 @@ def testBokehClientHistogramOnlyHisto():
         [4, {'plot_height': 40}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
     ]
-    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 def testBokehClientHistogramProfileA():
     output_file("test_BokehClientHistogramProfileA.html")
     figureArray = [
-        [['histoAB_1.bin_center_0'], ['histoAB_1.quantile_0', 'histoAB_1.quantile_1', 'histoAB_1.quantile_2']],
-        [['histoAB_1.bin_center_0'], ['histoAB_1.quantile_1', 'histoAB_1.mean']],
-        [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2"}],
-        [['histoAB_1.bin_center_0'], ['histoAB_1.std']],
+        [['histoAB_1.bin_center_0'], ['histoAB_1.quantile_0', 'histoAB_1.quantile_1', 'histoAB_1.quantile_2'], {"size":"size"}],
+        [['histoAB_1.bin_center_0'], ['histoAB_1.quantile_1', 'histoAB_1.mean'], {"size":"size"}],
+        [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2"}, {"size":"size"}],
+        [['histoAB_1.bin_center_0'], ['histoAB_1.std']], {"size":"size"},
         ["tableHisto", {"rowwise": False}]
     ]
     figureLayoutDesc=[
@@ -101,16 +106,16 @@ def testBokehClientHistogramProfileA():
         [4, {'plot_height': 40}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
     ]
-    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 def testBokehClientHistogramProfileB():
     output_file("test_BokehClientHistogramProfileB.html")
     figureArray = [
-        [['histoAB_0.bin_center_1'], ['histoAB_0.quantile_0', 'histoAB_0.quantile_1', 'histoAB_0.quantile_2']],
-        [['histoAB_0.bin_center_1'], ['histoAB_0.quantile_1', 'histoAB_0.mean']],
+        [['histoAB_0.bin_center_1'], ['histoAB_0.quantile_0', 'histoAB_0.quantile_1', 'histoAB_0.quantile_2'], {"size":"size"}],
+        [['histoAB_0.bin_center_1'], ['histoAB_0.quantile_1', 'histoAB_0.mean'], {"size":"size"}],
         [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2"}],
-        [['histoAB_0.bin_center_1'], ['histoAB_0.std']],
+        [['histoAB_0.bin_center_1'], ['histoAB_0.std'], {"size":"size"}],
         ["tableHisto", {"rowwise": False}]
     ]
     figureLayoutDesc=[
@@ -119,7 +124,7 @@ def testBokehClientHistogramProfileB():
         [4, {'plot_height': 40}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
     ]
-    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 
@@ -138,7 +143,7 @@ def testBokehClientHistogramRowwiseTable():
         [4, {'plot_height': 40}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
     ]
-    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 def testBokehClientHistogram3d():
@@ -147,10 +152,10 @@ def testBokehClientHistogram3d():
         {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]]},
     ]
     figureArray = [
-        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}]
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -158,7 +163,7 @@ def testBokehClientHistogram3d():
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
 def testBokehClientHistogram3d_colormap():
@@ -168,10 +173,10 @@ def testBokehClientHistogram3d_colormap():
         "range": [[0,1],[0,1],[0,1]]},
     ]
     figureArray = [
-        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }]
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -179,7 +184,7 @@ def testBokehClientHistogram3d_colormap():
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
 def testBokehClientHistogram3d_colormap_noscale():
@@ -189,10 +194,10 @@ def testBokehClientHistogram3d_colormap_noscale():
         "range": [[0,1],[0,1],[0,1]]},
     ]
     figureArray = [
-        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}]
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -200,7 +205,7 @@ def testBokehClientHistogram3d_colormap_noscale():
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
 #testBokehClientHistogram3d()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -161,6 +161,48 @@ def testBokehClientHistogram3d():
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
+def testBokehClientHistogram3d_colormap():
+    output_file("test_BokehClientHistogram_colormap.html")
+    histoArray = [
+        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
+        "range": [[0,1],[0,1],[0,1]]},
+    ]
+    figureArray = [
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7, "rescaleColorMapper": True }]
+    ]
+    figureLayoutDesc=[
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
+    ]
+    
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
+
+def testBokehClientHistogram3d_colormap_noscale():
+    output_file("test_BokehClientHistogram_colormap_noscale.html")
+    histoArray = [
+        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
+        "range": [[0,1],[0,1],[0,1]]},
+    ]
+    figureArray = [
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": 7}]
+    ]
+    figureLayoutDesc=[
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
+    ]
+    
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
+                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
+
 #testBokehClientHistogram3d()
 #testBokehClientHistogram()
 #testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -73,11 +73,14 @@ widgetParams=[
     ['slider', ['AA'], {'bins': 10}],
     ['multiSelect', ["DDC"]],
     ['select',["CC", 0, 1, 2, 3]],
-    ['select',["colorZ"], {"callback": "parameter", "default": 3}],
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
+    ['select',["colorZ"], {"callback": "parameter", "default": 3}],
 ]
-widgetLayoutDesc=[[0, 1, 2], [3, 4, 5], [6, 7],[8,9], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc={
+    "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8], {'sizing_mode': 'scale_width'}],
+    "Graphics": [[9], {'sizing_mode': 'scale_width'}]
+    }
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -113,7 +116,7 @@ def testBokehDrawArraySA_tree():
 
 
 #testBokehDrawArraySA_tree()
-#testBokehDrawArrayWidget()               # OK
+testBokehDrawArrayWidget()               # OK
 #testBokehDrawArrayWidgetNoScale()
 #testBokehDrawArrayDownsample()
 #testBokehDrawArrayQuery()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -45,13 +45,16 @@ df['errY']=df.A*0.02+0.02;
 df.head(10)
 df.meta.metaData = {'A.AxisTitle': "A (cm)", 'B.AxisTitle': "B (cm/s)", 'C.AxisTitle': "C (s)", 'D.AxisTitle': "D (a.u.)", 'Bool.AxisTitle': "A>half", 'E.AxisTitle': "Category"}
 
-
+parameterArray = [
+    {"name": "colorZ", "value":"EE", "options":["A", "B", "DD", "EE"], "type": "string"}
+]
 
 figureArray = [
 #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
     [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "varZ": "C", "errY": "errY", "errX":"0.01"}],
     [['A'], ['C+A', 'C-A', 'A/A']],
-    [['B'], ['C+B', 'C-B'], { "size": 7, "colorZvar": "EE", "errY": "errY", "rescaleColorMapper": True }],
+
+    [['B'], ['C+B', 'C-B'], { "size": 7, "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True }],
     [['D'], ['(A+B+C)*D'], {"size": 10, "errY": "errY"} ],
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
@@ -70,7 +73,7 @@ widgetParams=[
     ['slider', ['AA'], {'bins': 10}],
     ['multiSelect', ["DDC"]],
     ['select',["CC", 0, 1, 2, 3]],
-    ['select',["Bool"]],
+    ['select',["colorZ", "A", "B", "DD", "EE"], {"callback": "parameter", "default": 3}],
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
 ]
@@ -85,21 +88,21 @@ figureLayoutDesc=[
 
 def testBokehDrawArrayWidget():
     output_file("test_BokehDrawArrayWidget.html")
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode="scale_width")
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode="scale_width", parameterArray=parameterArray)
 
 def testBokehDrawArrayWidgetNoScale():
     output_file("test_BokehDrawArrayWidgetNoScale.html")
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None)
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None, parameterArray=parameterArray)
 
 
 def testBokehDrawArrayDownsample():
     output_file("test_BokehDrawArrayDownsample.html")
-    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200)
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200, parameterArray=parameterArray)
 
 def testBokehDrawArrayQuery():
     output_file("test_BokehDrawArrayQuery.html")
     df0 = df.copy()
-    xxx=bokehDrawSA.fromArray(df0, "BoolC == True", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200)
+    xxx=bokehDrawSA.fromArray(df0, "BoolC == True", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200, parameterArray=parameterArray)
     assert (df0.keys() == df.keys()).all()
 
 def testBokehDrawArraySA_tree():

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -73,7 +73,7 @@ widgetParams=[
     ['slider', ['AA'], {'bins': 10}],
     ['multiSelect', ["DDC"]],
     ['select',["CC", 0, 1, 2, 3]],
-    ['select',["colorZ", "A", "B", "DD", "EE"], {"callback": "parameter", "default": 3}],
+    ['select',["colorZ"], {"callback": "parameter", "default": 3}],
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
 ]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -46,16 +46,17 @@ df.head(10)
 df.meta.metaData = {'A.AxisTitle': "A (cm)", 'B.AxisTitle': "B (cm/s)", 'C.AxisTitle': "C (s)", 'D.AxisTitle': "D (a.u.)", 'Bool.AxisTitle': "A>half", 'E.AxisTitle': "Category"}
 
 parameterArray = [
-    {"name": "colorZ", "value":"EE", "options":["A", "B", "DD", "EE"], "type": "string"}
+    {"name": "colorZ", "value":"EE", "options":["A", "B", "DD", "EE"]},
+    {"name": "size", "value":7, "range":[0, 30]},
 ]
 
 figureArray = [
 #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
     [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "varZ": "C", "errY": "errY", "errX":"0.01"}],
-    [['A'], ['C+A', 'C-A', 'A/A']],
+    [['A'], ['C+A', 'C-A', 'A/A'], {"size":"size"}],
 
-    [['B'], ['C+B', 'C-B'], { "size": 7, "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True }],
-    [['D'], ['(A+B+C)*D'], {"size": 10, "errY": "errY"} ],
+    [['B'], ['C+B', 'C-B'], { "size":"size", "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True }],
+    [['D'], ['(A+B+C)*D'], {"colorZvar": "colorZ", "size": 10, "errY": "errY"} ],
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
     [['D'], ['D*10'], {"size": 10, "errY": "errY"}],
@@ -76,10 +77,11 @@ widgetParams=[
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
     ['select',["colorZ"], {"callback": "parameter", "default": 3}],
+    ['slider',["size"], {"callback": "parameter"}],
 ]
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8], {'sizing_mode': 'scale_width'}],
-    "Graphics": [[9], {'sizing_mode': 'scale_width'}]
+    "Graphics": [[9, 10], {'sizing_mode': 'scale_width'}]
     }
 
 figureLayoutDesc=[


### PR DESCRIPTION
This PR adds:

ParameterArray, a new parameter to BokehDrawSA. So far, it can only be used to add widget control to color Z, but it is planned to be used in different ways in the future.
Example usage in test_bokehDrawSA.py

Additionally, in order to make this work, the pull request had to completely remake the logic of color mappers, ~partially breaking #148 and #146 by removing the dirty hack that made it work (histoND projection color mappers no longer ignore rows with NaNs for computing ranges, shouldn't be that difficult to fix by adding an extra JS callback)~ This got fixed in 
89d4670.

Fixes a bug making ND histogram auto ranges not work, and improves ND histogram performance slightly (can be improved further by changing the selection callback, performance is worse when ranges are not defined, but it only ran faster because of a bug)

Also added support for multiple tabs in layout, and widgets for changing marker size. All in test_bokehDrawSA.py