### PR TITLE
MakeJSCallback cleanup - extracting downsampling to custom bokeh model

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
@@ -1,0 +1,20 @@
+from bokeh.core.properties import Instance, String, Int, List
+from bokeh.models import ColumnDataSource
+
+
+class DownsamplerCDS(ColumnDataSource):
+
+    __implementation__ = "DownsamplerCDS.ts"
+
+    # Below are all the "properties" for this model. Bokeh properties are
+    # class attributes that define the fields (and their types) that can be
+    # communicated automatically between Python and the browser. Properties
+    # also support type validation. More information about properties in
+    # can be found here:
+    #
+    #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
+
+    source = Instance(ColumnDataSource)
+    nPoints = Int(default=300, help="Number of points to downsample CDS to")
+    columns = List(String, default=[], help="The columns from the CDS to keep")
+    print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
@@ -16,5 +16,5 @@ class DownsamplerCDS(ColumnDataSource):
 
     source = Instance(ColumnDataSource)
     nPoints = Int(default=300, help="Number of points to downsample CDS to")
-    columns = List(String, default=[], help="The columns from the CDS to keep")
+    selectedColumns = List(String, default=[], help="The columns from the CDS to keep")
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -4,10 +4,10 @@ import * as p from "core/properties"
 export namespace DownsamplerCDS {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ColumnarDataSource.Props & {
+  export type Props = ColumnDataSource.Props & {
     source: p.Property<ColumnDataSource>
     nPoints: p.Property<number>
-    columns: p.Property<string[]>
+    selectedColumns: p.Property<string[]>
   }
 }
 
@@ -23,10 +23,10 @@ export class DownsamplerCDS extends ColumnDataSource {
   static __name__ = "DownsamplerCDS"
 
   static init_DownsamplerCDS() {
-    this.define<CDSCompress.Props>(({Ref, Int, Array, String})=>({
+    this.define<DownsamplerCDS.Props>(({Ref, Int, Array, String})=>({
       source:  [Ref(ColumnDataSource)],
       nPoints:    [ Int ],
-      columns:    [ List(String), [] ]
+      selectedColumns:    [ Array(String), [] ]
     }))
   }
 
@@ -38,11 +38,11 @@ export class DownsamplerCDS extends ColumnDataSource {
     super.initialize()
     this.booleans = null
     this._indices = []
-    update()
+    this.update()
   }
 
   update(){
-    const {source, nPoints, columns, booleans, _indices} = this
+    const {source, nPoints, selectedColumns, booleans, _indices} = this
     let l = source.length
     // Maybe add different downsampling strategies for small or large nPoints?
     // This is only efficient if the downsampling isn't too aggressive.
@@ -60,26 +60,27 @@ export class DownsamplerCDS extends ColumnDataSource {
       }
     }
     _indices.sort() // Might not be needed
-    for(const column of columns){
-      if(this.data[column] === undefined){
-        this.data[column] = []
-      } else {
-        this.data[column].length = 0
-      }
+    for(const column of selectedColumns){
+      this.data[column] = []
       for(let i=0; i < _indices.length; i++){
-        this.data[column].push(source.data[column][_indices[i]])
+        this.data[column][i] = (source.data[column][_indices[i]])
       }
     }
+    this.data.index = []
+    for(let i=0; i < _indices.length; i++){
+      this.data.index[i] = this._indices[i]
+    }
+    this.change.emit()
   }
-
+/*
   let j=0
   for(let i=0; i < _indices.length; i++){
-    //TODO: change selection indices
   }
+  */
 
   update_selection(){
-    const downsampled_indices = this.selected.indices
-    const original_indices = this.source.selected.indices
+    //const downsampled_indices = this.selected.indices
+    //const original_indices = this.source.selected.indices
     // TODO: Change original CDS selection indices
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -1,0 +1,86 @@
+import {ColumnDataSource} from "models/sources/column_data_source"
+import * as p from "core/properties"
+
+export namespace DownsamplerCDS {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ColumnarDataSource.Props & {
+    source: p.Property<ColumnDataSource>
+    nPoints: p.Property<number>
+    columns: p.Property<string[]>
+  }
+}
+
+export interface DownsamplerCDS extends DownsamplerCDS.Attrs {}
+
+export class DownsamplerCDS extends ColumnDataSource {
+  properties: DownsamplerCDS.Props
+
+  constructor(attrs?: Partial<DownsamplerCDS.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "DownsamplerCDS"
+
+  static init_DownsamplerCDS() {
+    this.define<CDSCompress.Props>(({Ref, Int, Array, String})=>({
+      source:  [Ref(ColumnDataSource)],
+      nPoints:    [ Int ],
+      columns:    [ List(String), [] ]
+    }))
+  }
+
+  public booleans: number[] | null// This is a hack to avoid expensive validation
+
+  private _indices: number[]
+
+  initialize(){
+    super.initialize()
+    this.booleans = null
+    this._indices = []
+    update()
+  }
+
+  update(){
+    const {source, nPoints, columns, booleans, _indices} = this
+    let l = source.length
+    // Maybe add different downsampling strategies for small or large nPoints?
+    // This is only efficient if the downsampling isn't too aggressive.
+    let nSelected = 0
+    _indices.length = 0
+    for (let i = 0; i < l; i++){
+      if(booleans === null || booleans[i]){
+        if(nSelected < nPoints){
+          _indices.push(i);
+        } else if(Math.random() < nPoints / (nSelected+1)) {
+          let randomIndex = Math.floor(Math.random()*nPoints)|0;
+          _indices[randomIndex] = i;
+        }
+        nSelected++;
+      }
+    }
+    _indices.sort() // Might not be needed
+    for(const column of columns){
+      if(this.data[column] === undefined){
+        this.data[column] = []
+      } else {
+        this.data[column].length = 0
+      }
+      for(let i=0; i < _indices.length; i++){
+        this.data[column].push(source.data[column][_indices[i]])
+      }
+    }
+  }
+
+  let j=0
+  for(let i=0; i < _indices.length; i++){
+    //TODO: change selection indices
+  }
+
+  update_selection(){
+    const downsampled_indices = this.selected.indices
+    const original_indices = this.source.selected.indices
+    // TODO: Change original CDS selection indices
+  }
+
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -47,7 +47,7 @@ export class DownsamplerCDS extends ColumnDataSource {
     _indices.length = source.get_length()!
     // Deck shuffling algorithm - for each card drawn, swap it with a random card in hand
     for(let i=0; i<_indices.length; ++i){
-      let random_index = (Math.random()*i) | 0
+      let random_index = (Math.random()*(i+1)) | 0
       _indices[i] = i
       _indices[i] = _indices[random_index]
       _indices[random_index] = i

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -59,17 +59,20 @@ export class DownsamplerCDS extends ColumnDataSource {
         nSelected++;
       }
     }
-    _indices.sort() // Might not be needed
-    for(const column of selectedColumns){
-      this.data[column] = []
+  //  _indices.sort() // Might not be needed
+    for(const columnName of selectedColumns){
+      this.data[columnName] = []
+      const colSource = source.data[columnName]
+      const colDest = this.data[columnName]
       for(let i=0; i < _indices.length; i++){
-        this.data[column][i] = (source.data[column][_indices[i]])
+        colDest[i] = (colSource[_indices[i]])
       }
     }
-    this.data.index = []
-    for(let i=0; i < _indices.length; i++){
-      this.data.index[i] = this._indices[i]
-    }
+//    this.data.index = []
+//    for(let i=0; i < _indices.length; i++){
+//      this.data.index[i] = this._indices[i]
+//    }
+    this.data.index = _indices
     this.change.emit()
   }
 /*

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -54,16 +54,8 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
         """
     const t0 = performance.now();
     const dataOrig = cdsOrig.data;
-    let dataSel = null;
-    if(cdsSel != null){
-        dataSel = cdsSel.data;
-        console.log('%f\t%f\t',dataOrig.index.length, dataSel.index.length);
-    }
     const nPointRender = options.nPointRender;
     let nSelected=0;
-    for (const i in dataSel){
-        dataSel[i] = [];
-    }
     const precision = 0.000001;
     const size = dataOrig.index.length;
     let isSelected = new Array(size);
@@ -141,29 +133,7 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
              }
         }*/
     }
-  /*  if(nPointRender > 0 && cdsSel != null){
-        for (let i = 0; i < size; i++){
-        let randomIndex = 0;
-            if (isSelected[i]){
-                if(nSelected < nPointRender){
-                    permutationFilter.push(i);
-                } else if(Math.random() < nPointRender / (nSelected+1)) {
-                    randomIndex = Math.floor(Math.random()*nPointRender)|0;
-                    permutationFilter[randomIndex] = i;
-                }
-                nSelected++;
-            }
-        }
-        nSelected = Math.min(nSelected, nPointRender);
-        for (const key in dataSel){
-            const colSel = dataSel[key];
-            const colOrig = dataOrig[key];
-            for(let i=0; i<nSelected; i++){
-                colSel[i] = colOrig[permutationFilter[i]];
-            }
-        }
-    }*/
-    
+   
     const t1 = performance.now();
     console.log(`Filtering took ${t1 - t0} milliseconds.`);
     const view = options.view;
@@ -182,7 +152,6 @@ def makeJScallbackOptimized(widgetDict, cdsOrig, cdsSel, **kwargs):
     const t2 = performance.now();
     console.log(`Histogramming took ${t2 - t1} milliseconds.`);
     if(nPointRender > 0 && cdsSel != null){
-        //cdsSel.change.emit();
         cdsSel.booleans = isSelected
         cdsSel.update()
         const t3 = performance.now();

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -19,7 +19,7 @@ from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJ
 from RootInteractive.InteractiveDrawing.bokeh.HistogramCDS import HistogramCDS
 from RootInteractive.InteractiveDrawing.bokeh.HistoNdCDS import HistoNdCDS
 import copy
-from RootInteractive.Tools.compressArray import *
+from RootInteractive.Tools.compressArray import compressCDSPipe
 from RootInteractive.InteractiveDrawing.bokeh.CDSCompress import CDSCompress
 from RootInteractive.InteractiveDrawing.bokeh.HistoStatsCDS import HistoStatsCDS
 from RootInteractive.InteractiveDrawing.bokeh.HistoNdProfile import HistoNdProfile

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1220,6 +1220,10 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                                 dfQuery, varNameZ = pandaGetOrMakeColumn(dfQuery, optionLocal['colorZvar'])
                                 columnNameDict[varNameZ] = True
                                 downsamplerColumns[varNameZ] = True
+                        if 'varZ' in optionLocal:
+                            dfQuery, varNameZ = pandaGetOrMakeColumn(dfQuery, optionLocal['varZ'])
+                            columnNameDict[varNameZ] = True
+                            downsamplerColumns[varNameZ] = True                            
                         # TODO: Make error bars client side to get rid of this mess. At least ND histogram does support them.
                         if ('errY' in optionLocal) and (optionLocal['errY'] != ''):
                             dfQuery, varNameErrY = pandaGetOrMakeColumn(dfQuery, optionLocal['errY'])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1228,13 +1228,13 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                             if varNameY+'_lower' not in dfQuery.columns:
                                 seriesLower = dfQuery[varNameY]-seriesErrY
                                 dfQuery[varNameY+'_lower'] = seriesLower
-                                columnNameDict[varNameY+'_lower'] = True
-                                downsamplerColumns[varNameY+'_lower'] = True
+                            columnNameDict[varNameY+'_lower'] = True
+                            downsamplerColumns[varNameY+'_lower'] = True
                             if varNameY+'_upper' not in dfQuery.columns:
                                 seriesUpper = dfQuery[varNameY]+seriesErrY
                                 dfQuery[varNameY+'_upper'] = seriesUpper
-                                columnNameDict[varNameY+'_upper'] = True
-                                downsamplerColumns[varNameY+'_upper'] = True
+                            columnNameDict[varNameY+'_upper'] = True
+                            downsamplerColumns[varNameY+'_upper'] = True
                         if ('errX' in optionLocal) and (optionLocal['errX'] != ''):
                             dfQuery, varNameErrX = pandaGetOrMakeColumn(dfQuery, optionLocal['errX'])
                             seriesErrX = dfQuery[varNameErrX]
@@ -1242,13 +1242,13 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                             if varNameX+'_lower' not in dfQuery.columns:
                                 seriesLower = dfQuery[varNameX]-seriesErrX
                                 dfQuery[varNameX+'_lower'] = seriesLower
-                                columnNameDict[varNameX+'_lower'] = True
-                                downsamplerColumns[varNameX+'_lower'] = True
+                            columnNameDict[varNameX+'_lower'] = True
+                            downsamplerColumns[varNameX+'_lower'] = True
                             if varNameX+'_upper' not in dfQuery.columns:
                                 seriesUpper = dfQuery[varNameX]+seriesErrX
                                 dfQuery[varNameX+'_upper'] = seriesUpper
-                                columnNameDict[varNameX+'_upper'] = True
-                                downsamplerColumns[varNameX+'_upper'] = True
+                            columnNameDict[varNameX+'_upper'] = True
+                            downsamplerColumns[varNameX+'_upper'] = True
                     else:
                         histogramDict[variables[1][j % lengthY]] = True
 
@@ -1271,7 +1271,7 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
     if "removeExtraColumns" in options and options["removeExtraColumns"]:
         dfQuery = dfQuery[columnNameDict]
 
-    return dfQuery, histogramDict, list(downsamplerColumns), columnNameDict, paramDict
+    return dfQuery, histogramDict, list(downsamplerColumns.keys()), columnNameDict, paramDict
 
 def bokehMakeParameters(parameterArray, histogramArray, figureArray, variableList, options={}):
     parameterDict = {}

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -1,9 +1,9 @@
-from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
-from RootInteractive.Tools.aliTreePlayer import *
-from RootInteractive.Tools.compressArray import arrayCompressionRelative8
-from bokeh.io import curdoc
-import pytest
-import matplotlib.pyplot as plt
+from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import bokehDrawSA
+from RootInteractive.Tools.compressArray import arrayCompressionRelative16
+import numpy as np
+import pandas as pd
+from bokeh.plotting import output_file
+
 def makePanda(step,sigma):
     noise = 0.1
     aa = np.arange(-1, 1, step)
@@ -15,7 +15,6 @@ def makePanda(step,sigma):
     wA = np.exp(-(a ** 2) / (2 * sigma ** 2))
     df0 = pd.DataFrame(data={'A': a.flatten(), 'B': b.flatten(), 'C': c.flatten(), 'W': w.flatten(),'Wa': w.flatten()})
     return df0,a,b,c,w
-
 
 figureArray = [
     [['A'], ['histoA']],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -28,6 +28,7 @@ markerFactor=factor_mark('DDC', MARKERS, ["A0","A1","A2","A3","A4"] )
 colorFactor=factor_cmap('DDC', 'Category10_6', ["A0","A1","A2","A3","A4"] )
 
 mapDDC={0:"A0",1:"A1",2:"A2",3:"A3",4:"A4"}
+df["B"]=np.linspace(0,1,20000)
 df.eval("Bool=A>0.5", inplace=True)
 df.eval("BoolB=B>0.5", inplace=True)
 df.eval("BoolC=C>0.1", inplace=True)


### PR DESCRIPTION
Relates to #76 
This pull request:

Fixes a bug with imports in testBokehClientHistogramWeight.py - the test only worked because of a star import in bokehTools that was resulting in name collisions

bokehTools now only imports compressCDSPipe from Tools.compressArray - this was causing a weird bug, was probably supposed to be removed when the code was merged to master

Extracts downsampling code from makeJSCallback to its own bokeh extension, downsamplerCDS, and changed the downsampling algorithm to return predictable indices which are shuffled on initiation, possibly fixing #76 

I have encountered a weird bug when changing the displayed selection removed all selected points, the bug disappeared when inserting a breakpointand then they returned, the selected points were deselected, but I cannot reproduce the bug now.