### PR TITLE
Added legend options to parameter array

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -804,9 +804,21 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         if figureI.legend:
             figureI.legend.click_policy = "hide"
             if optionLocal["legendTitle"] is not None:
+                logging.warn("legendTitle is deprecated, please use the 'title' field in 'legend_options'")
                 figureI.legend.title = optionLocal["legendTitle"]
             elif figure_cds_name != "":
                 figureI.legend.title = figure_cds_name
+            if 'legend_options' in optionLocal:
+                legend_options = optionLocal['legend_options'].copy()
+                legend_options_parameters = {}
+                for i, iOption in legend_options.items():
+                    if iOption in parameterDict:
+                        legend_options_parameters[i] = paramDict[iOption]
+                for i, iOption in legend_options_parameters.items():
+                    legend_options[i] = iOption['value']
+                figureI.legend.update(**legend_options)
+                for i, iOption in legend_options_parameters.items():
+                    iOption["subscribed_events"].append(["value", figureI.legend[0], i])        
         #        zAxisTitle=zAxisTitle[:-1]
         #        if(len(zAxisTitle)>0):
         #            plotTitle += " Color:" + zAxisTitle

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -49,18 +49,18 @@ df.meta.metaData = {'A.AxisTitle': "A (cm)", 'B.AxisTitle': "B (cm/s)", 'C.AxisT
 parameterArray = [
     {"name": "colorZ", "value":"EE", "options":["A", "B", "DD", "EE"]},
     {"name": "size", "value":7, "range":[0, 30]},
+    {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
 ]
 
 figureArray = [
 #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
     [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "varZ": "C", "errY": "errY", "errX":"0.01"}],
-    [['A'], ['C+A', 'C-A', 'A/A'], {"size":"size"}],
-
-    [['B'], ['C+B', 'C-B'], { "size":"size", "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True }],
-    [['D'], ['(A+B+C)*D'], {"colorZvar": "colorZ", "size": 10, "errY": "errY"} ],
+    [['A'], ['C+A', 'C-A', 'A/A'], {"size":"size", "legend_options": {"label_text_font_size": "legendFontSize"}}],
+    [['B'], ['C+B', 'C-B'], { "size":"size", "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True , "legend_options": {"label_text_font_size": "legendFontSize"}}],
+    [['D'], ['(A+B+C)*D'], {"colorZvar": "colorZ", "size": 10, "errY": "errY", "legend_options": {"label_text_font_size": "legendFontSize"}} ],
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
-    [['D'], ['D*10'], {"size": 10, "errY": "errY"}],
+    [['D'], ['D*10'], {"size": 10, "errY": "errY", "legend_options": {"label_text_font_size": "legendFontSize"}}],
 ]
 #widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1), multiselect.E(0,1,2,3,4)"
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"
@@ -79,10 +79,11 @@ widgetParams=[
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
     ['select',["colorZ"], {"callback": "parameter", "default": 3}],
     ['slider',["size"], {"callback": "parameter"}],
+    ['select',["legendFontSize"], {"callback": "parameter", "default": 2}],
 ]
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8], {'sizing_mode': 'scale_width'}],
-    "Graphics": [[9, 10], {'sizing_mode': 'scale_width'}]
+    "Graphics": [[9, 10, 11], {'sizing_mode': 'scale_width'}]
     }
 
 figureLayoutDesc={
@@ -125,7 +126,7 @@ def testBokehDrawArraySA_tree():
 
 
 #testBokehDrawArraySA_tree()
-testBokehDrawArrayWidget()               # OK
+#testBokehDrawArrayWidget()               # OK
 #testBokehDrawArrayWidgetNoScale()
 #testBokehDrawArrayDownsample()
 #testBokehDrawArrayQuery()


### PR DESCRIPTION
This PR adds legend options to parameter array, interface is same as in bokeh, see 

https://docs.bokeh.org/en/latest/docs/reference/models/annotations.html#legend

Work fully with parameters from parameterArray, test in test_bokehDrawSA.py
Relates to #157 