### PR TITLE
Compression bugfix and footgun removal

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.py
@@ -1,8 +1,8 @@
 from bokeh.core.properties import Instance, String, Float, Int, List, Any, Dict
-from bokeh.models import ColumnarDataSource
+from bokeh.models import ColumnDataSource
 
 
-class CDSCompress(ColumnarDataSource):
+class CDSCompress(ColumnDataSource):
     __javascript__ = ["https://cdnjs.cloudflare.com/ajax/libs/pako/2.0.2/pako.min.js","https://cdnjs.cloudflare.com/ajax/libs/Base64/1.1.0/base64.js"]
     __implementation__ = "CDSCompress.ts"
 
@@ -13,7 +13,6 @@ class CDSCompress(ColumnarDataSource):
     # can be found here:
     #
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
-    source = Instance(ColumnarDataSource)
     inputData=Dict(String, Any)
     sizeMap=Dict(String, Any)
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -1,4 +1,3 @@
-import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import {ColumnDataSource} from "models/sources/column_data_source"
 import * as p from "core/properties"
 //import * as pako from './pako/'
@@ -12,8 +11,7 @@ declare const  pako : any
 export namespace CDSCompress {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ColumnarDataSource.Props & {
-    source: p.Property<ColumnDataSource>
+  export type Props = ColumnDataSource.Props & {
       inputData :    p.Property<Record<string, any>>
       sizeMap :    p.Property<Record<string, any>>
   }
@@ -21,7 +19,7 @@ export namespace CDSCompress {
 
 export interface CDSCompress extends CDSCompress.Attrs {}
 
-export class CDSCompress extends ColumnarDataSource {
+export class CDSCompress extends ColumnDataSource {
   properties: CDSCompress.Props
 
   constructor(attrs?: Partial<CDSCompress.Attrs>) {
@@ -32,8 +30,7 @@ export class CDSCompress extends ColumnarDataSource {
 
   static init_CDSCompress() {
 
-    this.define<CDSCompress.Props>(({Ref})=>({
-      source:  [Ref(ColumnDataSource)],
+    this.define<CDSCompress.Props>(()=>({
         inputData:    [ p.Instance ],
         sizeMap:    [ p.Instance ]
     }))
@@ -44,7 +41,6 @@ export class CDSCompress extends ColumnarDataSource {
     //this.data = {}
     console.info("CDSCompress::initialize")
     this.inflateCompressedBokehObjectBase64()
-    //this.update_range()
   }
   inflateCompressedBokehBase64(arrayIn: any ) {
     let arrayOut=arrayIn.array
@@ -100,7 +96,5 @@ export class CDSCompress extends ColumnarDataSource {
         }
     return objectOut
   }
-
-  public view: number[] | null
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -544,26 +544,30 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
     columnNameDict, parameterDict = makeDerivedColumns(dfQuery, figureArray, histogramArray=histogramArray,
                                                        parameterArray=parameterArray, options=options)
 
-    try:
-        cdsFull = ColumnDataSource(dfQuery)
-        if downsamplerColumns:
-            source = DownsamplerCDS(source=cdsFull, nPoints=options['nPointRender'], selectedColumns=downsamplerColumns)
-        else:
-            source = None
-    except:
-        logging.error("Invalid source:", source)
-    # define default options
-
     plotArray = []
     colorAll = all_palettes[options['colors']]
     colorMapperDict = {}
     cdsHistoSummary = None
 
+    cdsFull = None
     if options['arrayCompression'] is not None:
         print("compressCDSPipe")
         cdsCompress0, sizeMap= compressCDSPipe(dfQuery,options["arrayCompression"],1)
-        cdsCompress=CDSCompress(source=None,inputData=cdsCompress0, sizeMap=sizeMap)
+        cdsCompress=CDSCompress(inputData=cdsCompress0, sizeMap=sizeMap)
         cdsFull=cdsCompress
+    else:
+        try:
+            cdsFull = ColumnDataSource(dfQuery)
+        except:
+            logging.error("Invalid source:", source)
+
+    if downsamplerColumns:
+        dummy_data = {}
+        for i in downsamplerColumns:
+            dummy_data[i] = []
+        source = DownsamplerCDS(source=cdsFull, nPoints=options['nPointRender'], selectedColumns=downsamplerColumns, data=dummy_data)
+    else:
+        source = None
 
     histogramDict = bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray, histogramDict)
     cdsDict = options["cdsDict"]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
@@ -1,7 +1,8 @@
 import pandas as pd
 import numpy as np
 from scipy.stats import entropy
-from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
+from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import bokehDrawSA
+from bokeh.plotting import output_file
 from RootInteractive.Tools.compressArray import *
 import time
 import re
@@ -262,7 +263,7 @@ def test_compressCDSPipe():
 
 def test_CompressionCDSPipeDraw():
     df = pd.DataFrame(np.random.random_sample(size=(100000, 4)), columns=list('ABCD'))
-    df["AA"] = ((df.A * 10).round(0)).astype(CategoricalDtype(ordered=True))
+    df["AA"] = ((df.A * 10).round(0)).astype(pd.CategoricalDtype(ordered=True))
     figureArray = [
        [['A*10'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "errY": "0.1", "errX":"0.01"}],
         [['AA'], ['C+A', 'C-A', 'A/A']],


### PR DESCRIPTION
This PR fixes these 3 bugs:

Imports in test_Compression being wrong

DownsamplerCDS causing validation errors - filled the CDS with dummy data at the start

Compression not working if DownsamplerCDS present - regrassion caused by #159 this was caused by the data source for the downsampler being assigned cdsFull shadowing the real cdsCompress - reordering the lines to remove spaghetti code however caused it to not work because of having to downcast to ColumnarDataSource, this was fixed by changing the CDSCompress model.