### PR TITLE
Auto tooltips for ND histogram projections

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1339,6 +1339,8 @@ def defaultNDProfileTooltips(varNames, axis_idx, quantiles, sumRanges):
     tooltips.append(("Std. " + varNames[axis_idx], "@std"))
     for i, iQuantile in enumerate(quantiles):
         tooltips.append((f"Quantile {iQuantile} {varNames[axis_idx]}", "@quantile_" + str(i)))
+    for i, iRange in enumerate(sumRanges):
+        tooltips.append((f"Sum_normed {varNames[axis_idx]} in [{iRange[0]}, {iRange[1]}]", "@sum_normed_" + str(i)))
     return tooltips
 
 def getOrMakeColumn(dfQuery, column, cdsName):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -14,7 +14,7 @@ import pyparsing
 from IPython import get_ipython
 from bokeh.models.widgets import *
 from bokeh.models import CustomJS, ColumnDataSource
-from RootInteractive.Tools.pandaTools import *
+from RootInteractive.Tools.pandaTools import pandaGetOrMakeColumn
 from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJSGraph3D
 from RootInteractive.InteractiveDrawing.bokeh.HistogramCDS import HistogramCDS
 from RootInteractive.InteractiveDrawing.bokeh.HistoNdCDS import HistoNdCDS
@@ -24,7 +24,7 @@ from RootInteractive.InteractiveDrawing.bokeh.CDSCompress import CDSCompress
 from RootInteractive.InteractiveDrawing.bokeh.HistoStatsCDS import HistoStatsCDS
 from RootInteractive.InteractiveDrawing.bokeh.HistoNdProfile import HistoNdProfile
 from RootInteractive.InteractiveDrawing.bokeh.DownsamplerCDS import DownsamplerCDS
-import string
+import re
 
 # tuple of Bokeh markers
 bokehMarkers = ["square", "circle", "triangle", "diamond", "square_cross", "circle_cross", "diamond_cross", "cross",
@@ -715,7 +715,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if optionLocal['colorZvar'] in paramDict:
                 paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", color_bar, "title"])
 
-        defaultHoverToolRenderers = []
+        hover_tool_renderers = {}
 
         figure_cds_name = None
 
@@ -789,7 +789,14 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionLocal['size'] in paramDict:
                     paramDict[optionLocal['size']]["subscribed_events"].append(["value", drawnGlyph.glyph, "size"])
                 if cds_name is None:
-                    defaultHoverToolRenderers.append(drawnGlyph)
+                    if "" not in hover_tool_renderers:
+                        hover_tool_renderers[""] = []
+                    hover_tool_renderers[""].append(drawnGlyph)
+                elif cds_name in histogramDict:
+                    if histogramDict[cds_name]["type"] == "profile":
+                        if cds_name not in hover_tool_renderers:
+                            hover_tool_renderers[cds_name] = []
+                        hover_tool_renderers[cds_name].append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
                     errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)
                     if optionLocal["colorZvar"] in paramDict:
@@ -809,8 +816,14 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
 
         if color_bar != None:
             figureI.add_layout(color_bar, 'right')
-        if defaultHoverToolRenderers:
-            figureI.add_tools(HoverTool(tooltips=optionLocal["tooltips"], renderers=defaultHoverToolRenderers))
+        for iCds, iRenderers in hover_tool_renderers.items():
+            if iCds == "":
+                tooltips = optionLocal["tooltips"]
+            elif iCds in histogramDict and histogramDict[iCds]["type"] == "profile":
+                profile_description = histogramDict[iCds]
+                tooltips = defaultNDProfileTooltips(profile_description["variables"], profile_description["axis"],
+                                                    profile_description["quantiles"],  profile_description["sum_range"])
+            figureI.add_tools(HoverTool(tooltips=tooltips, renderers=iRenderers))
         if figureI.legend:
             figureI.legend.click_policy = "hide"
             if optionLocal["legendTitle"] is not None:
@@ -1139,7 +1152,7 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                                                 sum_range=optionLocal["sum_range"])
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
-                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"]}
+                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "axis": i}
                 histoDict[histoName]["profiles"] = profilesDict
         else:
             sampleVarNames = []
@@ -1159,7 +1172,7 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
                                                 sum_range=optionLocal["sum_range"])
                     profilesDict[i] = cdsProfile
                     histoDict[histoName+"_"+str(i)] = {"cds": cdsProfile, "type": "profile", "name": histoName+"_"+str(i), "variables": sampleVars,
-                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"]} 
+                    "quantiles": optionLocal["quantiles"], "sum_range": optionLocal["sum_range"], "axis": i} 
                 histoDict[histoName]["profiles"] = profilesDict
 
     return histoDict
@@ -1317,6 +1330,17 @@ def bokehMakeParameters(parameterArray, histogramArray, figureArray, variableLis
                                 raise ValueError("Missing range for parameter: ", paramSize["name"])
     return parameterDict
 
+def defaultNDProfileTooltips(varNames, axis_idx, quantiles, sumRanges):
+    tooltips = []
+    for i, iAxis in enumerate(varNames):
+        if i != axis_idx:
+            tooltips.append((iAxis, "[@{bin_bottom_" + str(i) + "}, @{bin_top_" + str(i) + "}]"))
+    tooltips.append(("Mean " + varNames[axis_idx], "@mean"))
+    tooltips.append(("Std. " + varNames[axis_idx], "@std"))
+    for i, iQuantile in enumerate(quantiles):
+        tooltips.append(("Quantile " + iQuantile + " " + varNames[axis_idx], "@quantile_" + str(i)))
+    return tooltips
+
 def getOrMakeColumn(dfQuery, column, cdsName):
     if '.' in column:
         c = column.split('.')
@@ -1332,21 +1356,13 @@ def getTooltipColumns(tooltips):
     if isinstance(tooltips, str):
         return {}
     result = {}
+    tooltip_regex = re.compile(r'@(?:\w+|\{[^\}]*\})')
     for iTooltip in tooltips:
-        fields = iTooltip[1].split('@')
-        for iField in fields[1:]:
-            if iField[0] == '{':
-                result[iField[1:].split('}')[0]] = True
+        for iField in tooltip_regex.findall(iTooltip[1]):
+            if iField[1] == '{':
+                result[iField[2:-1]] = True
             else:
-                # HACK: Ghetto regex - probably regexes aren't even the right way of parsing this
-                isOK = True
-                for i in range(len(iField)):  
-                    if iField[i] in string.whitespace + string.punctuation:
-                        result[iField[:i]] = True
-                        isOK = False
-                        break
-                if isOK:
-                    result[iField] = True
+                result[iField[1:]] = True
     return result
 
 def getHistogramAxisTitle(histoDict, varName, cdsName, removeCdsName=True):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1339,10 +1339,14 @@ def getTooltipColumns(tooltips):
                 result[iField[1:].split('}')[0]] = True
             else:
                 # HACK: Ghetto regex - probably regexes aren't even the right way of parsing this
+                isOK = True
                 for i in range(len(iField)):  
                     if iField[i] in string.whitespace + string.punctuation:
                         result[iField[:i]] = True
+                        isOK = False
                         break
+                if isOK:
+                    result[iField] = True
     return result
 
 def getHistogramAxisTitle(histoDict, varName, cdsName, removeCdsName=True):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1338,7 +1338,7 @@ def defaultNDProfileTooltips(varNames, axis_idx, quantiles, sumRanges):
     tooltips.append(("Mean " + varNames[axis_idx], "@mean"))
     tooltips.append(("Std. " + varNames[axis_idx], "@std"))
     for i, iQuantile in enumerate(quantiles):
-        tooltips.append(("Quantile " + iQuantile + " " + varNames[axis_idx], "@quantile_" + str(i)))
+        tooltips.append((f"Quantile {iQuantile} {varNames[axis_idx]}", "@quantile_" + str(i)))
     return tooltips
 
 def getOrMakeColumn(dfQuery, column, cdsName):

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -64,7 +64,7 @@ figureArray = [
 ]
 #widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1), multiselect.E(0,1,2,3,4)"
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"
-tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)"), ("ErrY", "(@errY)")]
+tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)"), ("ErrY", "@errY")]
 
 widgetParams=[
     ['range', ['A']],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -64,11 +64,12 @@ figureArray = [
 ]
 #widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1), multiselect.E(0,1,2,3,4)"
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"
-tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)")]
+tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)"), ("ErrY", "(@errY)")]
 
 widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1]],
+
     ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
@@ -107,7 +108,6 @@ def testBokehDrawArrayWidgetNoScale():
     output_file("test_BokehDrawArrayWidgetNoScale.html")
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None, parameterArray=parameterArray)
 
-
 def testBokehDrawArrayDownsample():
     output_file("test_BokehDrawArrayDownsample.html")
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, nPointRender=200, parameterArray=parameterArray)
@@ -126,7 +126,7 @@ def testBokehDrawArraySA_tree():
 
 
 #testBokehDrawArraySA_tree()
-#testBokehDrawArrayWidget()               # OK
+testBokehDrawArrayWidget()               # OK
 #testBokehDrawArrayWidgetNoScale()
 #testBokehDrawArrayDownsample()
 #testBokehDrawArrayQuery()


### PR DESCRIPTION
Relates to #159, #156 and #121 

This is not a complete fix, as tooltips for ND histograms only work using the old interface. There is no need for the user to do anything, these tooltips are generated automatically.

This PR also fixes a bug introduced in #156 that caused the color bars to not get updated numbers and tickers when the color mappers got updated to a different variable and a bug introduced in #159 that made fields in tooltips not survive the downsampling process (and also the process that removed columns before they were sent to the client).