### PR TITLE
Removed error bar spaghetti and fixed some warnings

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
@@ -1,8 +1,8 @@
 from bokeh.core.properties import Instance, String, Any, Dict
-from bokeh.models import ColumnarDataSource, ColumnDataSource
+from bokeh.models import ColumnarDataSource
 
 
-class CDSAlias(ColumnDataSource):
+class CDSAlias(ColumnarDataSource):
     __implementation__ = "CDSAlias.ts"
 
     # Below are all the "properties" for this model. Bokeh properties are

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -30,6 +30,7 @@ export class CDSAlias extends ColumnarDataSource {
 
   initialize(){
     super.initialize()
+    this.data = {}
     this.compute_functions()
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -1,11 +1,10 @@
-import {ColumnDataSource} from "models/sources/column_data_source"
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import * as p from "core/properties"
 
 export namespace CDSAlias {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ColumnDataSource.Props & {
+  export type Props = ColumnarDataSource.Props & {
     source: p.Property<ColumnarDataSource>
     mapping: p.Property<Record<string, any>>
   }
@@ -13,7 +12,7 @@ export namespace CDSAlias {
 
 export interface CDSAlias extends CDSAlias.Attrs {}
 
-export class CDSAlias extends ColumnDataSource {
+export class CDSAlias extends ColumnarDataSource {
   properties: CDSAlias.Props
 
   constructor(attrs?: Partial<CDSAlias.Attrs>) {

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
@@ -1,8 +1,8 @@
 from bokeh.core.properties import Instance, String, Int, List
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnarDataSource
 
 
-class DownsamplerCDS(ColumnDataSource):
+class DownsamplerCDS(ColumnarDataSource):
 
     __implementation__ = "DownsamplerCDS.ts"
 
@@ -14,7 +14,7 @@ class DownsamplerCDS(ColumnDataSource):
     #
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
 
-    source = Instance(ColumnDataSource)
+    source = Instance(ColumnarDataSource)
     nPoints = Int(default=300, help="Number of points to downsample CDS to")
     selectedColumns = List(String, default=[], help="The columns from the CDS to keep")
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.py
@@ -1,8 +1,8 @@
 from bokeh.core.properties import Instance, String, Float, Int, List, Dict, Any
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnarDataSource
 
 
-class HistoNdCDS(ColumnDataSource):
+class HistoNdCDS(ColumnarDataSource):
 
     __implementation__ = "HistoNdCDS.ts"
 
@@ -14,7 +14,7 @@ class HistoNdCDS(ColumnDataSource):
     #
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
 
-    source = Instance(ColumnDataSource, help="Source from which to take the data to histogram")
+    source = Instance(ColumnarDataSource, help="Source from which to take the data to histogram")
     sample_variables = List(String, help="Names of the columns used for binning")
     weights = String(default=None)
     # TODO: Support auto nbins in the future - 2n-th root of total entries?

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -1,11 +1,11 @@
-import {ColumnDataSource} from "models/sources/column_data_source"
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import * as p from "core/properties"
 
 export namespace HistoNdCDS {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ColumnDataSource.Props & {
-    source: p.Property<ColumnDataSource>
+  export type Props = ColumnarDataSource.Props & {
+    source: p.Property<ColumnarDataSource>
 //    view: p.Property<number[] | null>
     nbins:        p.Property<number[]>
     range:    p.Property<(number[] | null)[] | null>
@@ -17,7 +17,7 @@ export namespace HistoNdCDS {
 
 export interface HistoNdCDS extends HistoNdCDS.Attrs {}
 
-export class HistoNdCDS extends ColumnDataSource {
+export class HistoNdCDS extends ColumnarDataSource {
   properties: HistoNdCDS.Props
 
   constructor(attrs?: Partial<HistoNdCDS.Attrs>) {
@@ -35,7 +35,7 @@ export class HistoNdCDS extends ColumnDataSource {
   static init_HistoNdCDS() {
 
     this.define<HistoNdCDS.Props>(({Ref, Array, Nullable, Number, Int, String})=>({
-      source:  [Ref(ColumnDataSource)],
+      source:  [Ref(ColumnarDataSource)],
 //      view:         [Nullable(Array(Int)), null], - specifying this as a bokeh property causes a drastic drop in performance
       nbins:        [Array(Int)],
       range:    [Nullable(Array(Nullable(Array(Number))))],

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -80,7 +80,7 @@ class bokehDrawSA(object):
         if query is None:
             self.dataSource = df.copy()
         else:
-            self.dataSource = df.query(query)
+            self.dataSource = df.query(query).copy()
         if hasattr(df, 'metaData'):
             self.dataSource.metaData = df.metaData
         self.cdsOrig = ColumnDataSource(self.dataSource)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,6 +1,7 @@
 from io import UnsupportedOperation
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import ColumnDataSource, ColorBar, HoverTool, VBar, HBar, Quad
+from bokeh.models.transforms import CustomJSTransform
 from bokeh.models.mappers import LinearColorMapper
 from bokeh.models.widgets.tables import ScientificFormatter, DataTable
 from bokeh.transform import *
@@ -27,6 +28,7 @@ from RootInteractive.InteractiveDrawing.bokeh.HistoNdProfile import HistoNdProfi
 from RootInteractive.InteractiveDrawing.bokeh.DownsamplerCDS import DownsamplerCDS
 from RootInteractive.InteractiveDrawing.bokeh.CDSAlias import CDSAlias
 from RootInteractive.InteractiveDrawing.bokeh.CustomJSNAryFunction import CustomJSNAryFunction
+from bokeh.transform import transform as bokehTransform
 import re
 
 # tuple of Bokeh markers
@@ -855,12 +857,16 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                             hover_tool_renderers[cds_name] = []
                         hover_tool_renderers[cds_name].append(drawnGlyph)
                 if ('errX' in optionLocal.keys()) and (optionLocal['errX'] != '') and (cds_name is None):
-                    errorX = HBar(y=varNameY, height=0, left=varNameX+"_lower", right=varNameX+"_upper", line_color=color)
+                    dfQuery, varErrX = pandaGetOrMakeColumn(dfQuery, optionLocal['errX'])
+                    errWidthX = bokehTransform(varErrX, CustomJSTransform(v_func="return xs.map((x)=>2*x)"))
+                    errorX = VBar(top=varNameY, bottom=varNameY, width=errWidthX, x=varNameX, line_color=color)
                     if "colorZvar" in optionLocal and optionLocal["colorZvar"] in paramDict:
                         paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": errorX}, code=colorMapperCallback)])
                     figureI.add_glyph(source, errorX)
                 if ('errY' in optionLocal.keys()) and (optionLocal['errY'] != '') and (cds_name is None):
-                    errorY = VBar(x=varNameX, width=0, bottom=varNameY+"_lower", top=varNameY+"_upper", line_color=color)
+                    dfQuery, varErrY = pandaGetOrMakeColumn(dfQuery, optionLocal['errY'])
+                    errWidthY = bokehTransform(varErrY, CustomJSTransform(v_func="return xs.map((x)=>2*x)"))
+                    errorY = HBar(left=varNameX, right=varNameX, height=errWidthY, y=varNameY, line_color=color)
                     if "colorZvar" in optionLocal and optionLocal["colorZvar"] in paramDict:
                         paramDict[optionLocal['colorZvar']]["subscribed_events"].append(["value", CustomJS(args={"glyph": errorY}, code=colorMapperCallback)])
                     figureI.add_glyph(source, errorY)
@@ -1312,30 +1318,12 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                             dfQuery, varNameErrY = pandaGetOrMakeColumn(dfQuery, optionLocal['errY'])
                             seriesErrY = dfQuery[varNameErrY]
                             columnNameDict[varNameErrY] = True
-                            if varNameY+'_lower' not in dfQuery.columns:
-                                seriesLower = dfQuery[varNameY]-seriesErrY
-                                dfQuery[varNameY+'_lower'] = seriesLower
-                            columnNameDict[varNameY+'_lower'] = True
-                            downsamplerColumns[varNameY+'_lower'] = True
-                            if varNameY+'_upper' not in dfQuery.columns:
-                                seriesUpper = dfQuery[varNameY]+seriesErrY
-                                dfQuery[varNameY+'_upper'] = seriesUpper
-                            columnNameDict[varNameY+'_upper'] = True
-                            downsamplerColumns[varNameY+'_upper'] = True
+                            downsamplerColumns[varNameErrY] = True
                         if ('errX' in optionLocal) and (optionLocal['errX'] != ''):
                             dfQuery, varNameErrX = pandaGetOrMakeColumn(dfQuery, optionLocal['errX'])
                             seriesErrX = dfQuery[varNameErrX]
                             columnNameDict[varNameErrX] = True
-                            if varNameX+'_lower' not in dfQuery.columns:
-                                seriesLower = dfQuery[varNameX]-seriesErrX
-                                dfQuery[varNameX+'_lower'] = seriesLower
-                            columnNameDict[varNameX+'_lower'] = True
-                            downsamplerColumns[varNameX+'_lower'] = True
-                            if varNameX+'_upper' not in dfQuery.columns:
-                                seriesUpper = dfQuery[varNameX]+seriesErrX
-                                dfQuery[varNameX+'_upper'] = seriesUpper
-                            columnNameDict[varNameX+'_upper'] = True
-                            downsamplerColumns[varNameX+'_upper'] = True
+                            downsamplerColumns[varNameErrX] = True
                         if 'tooltips' in optionLocal:
                             tooltipColumns = getTooltipColumns(optionLocal['tooltips'])
                             columnNameDict.update(tooltipColumns)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -632,10 +632,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         cdsFull = CDSAlias(source=cdsFull, mapping=columnNameDict)
 
     if downsamplerColumns:
-        dummy_data = {}
-        for i in downsamplerColumns:
-            dummy_data[i] = []
-        source = DownsamplerCDS(source=cdsFull, nPoints=options['nPointRender'], selectedColumns=downsamplerColumns, data=dummy_data)
+        source = DownsamplerCDS(source=cdsFull, nPoints=options['nPointRender'], selectedColumns=downsamplerColumns)
     else:
         source = None
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -535,7 +535,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
     }
     options.update(kwargs)
     if query is not None:
-        dfQuery = dataFrame.query(query)
+        dfQuery = dataFrame.query(query).copy()
         if hasattr(dataFrame, 'metaData'):
             dfQuery.metaData = dataFrame.metaData
             logging.info(dfQuery.metaData)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.py
@@ -1,5 +1,5 @@
 from bokeh.core.properties import Instance, String, Dict, Any
-from bokeh.models import ColumnDataSource, LayoutDOM
+from bokeh.models import ColumnarDataSource, LayoutDOM
 # see options in https://visjs.github.io/vis-graph3d/docs/graph3d/index.html
 
 
@@ -24,7 +24,7 @@ class BokehVisJSGraph3D(LayoutDOM):
 
     # This is a Bokeh ColumnDataSource that can be updated in the Bokeh
     # server by Python code
-    data_source = Instance(ColumnDataSource)
+    data_source = Instance(ColumnarDataSource)
 
     # The vis.js library that we are wrapping expects data for x, y, and z.
     # The data will actually be stored in the ColumnDataSource, but these

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehVisJS3DGraph.ts
@@ -5,7 +5,7 @@
 // Making it easy to hook up python data analytics tools (NumPy, SciPy,
 // Pandas, etc.) to web presentations using the Bokeh server.
 import {LayoutDOM, LayoutDOMView} from "models/layouts/layout_dom"
-import {ColumnDataSource} from "models/sources/column_data_source"
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import {LayoutItem} from "core/layout"
 import * as p from "core/properties"
 
@@ -127,7 +127,7 @@ export namespace BokehVisJSGraph3D {
     z: p.Property<string>
     style: p.Property<string>
     options3D:  p.Property<Record<string, any>>
-    data_source: p.Property<ColumnDataSource>
+    data_source: p.Property<ColumnarDataSource>
   }
 }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -32,17 +32,17 @@ df["B"]=np.linspace(0,1,20000)
 df.eval("Bool=A>0.5", inplace=True)
 df.eval("BoolB=B>0.5", inplace=True)
 df.eval("BoolC=C>0.1", inplace=True)
-df["A"]=df["A"].round(3);
-df["A"][15] = math.nan
-df["B"]=df["B"].round(3);
-df["C"]=df["C"].round(3);
-df["D"]=df["D"].round(3);
+df["A"]=df["A"].round(3)
+df.loc[15]["A"] = math.nan
+df["B"]=df["B"].round(3)
+df["C"]=df["C"].round(3)
+df["D"]=df["D"].round(3)
 df["AA"]=((df.A*10).round(0)).astype(CategoricalDtype(ordered=True))
 df["CC"]=((df.C*5).round(0)).astype(int)
 df["DD"]=((df.D*4).round(0)).astype(int)
 df["DDC"]=((df.D*4).round(0)).astype(int).map(mapDDC)
 df["EE"]=(df.E*4).round(0)
-df['errY']=df.A*0.02+0.02;
+df['errY']=df.A*0.02+0.02
 df.head(10)
 df.meta.metaData = {'A.AxisTitle': "A (cm)", 'B.AxisTitle': "B (cm/s)", 'C.AxisTitle': "C (s)", 'D.AxisTitle': "D (a.u.)", 'Bool.AxisTitle': "A>half", 'E.AxisTitle': "Category"}
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -33,7 +33,7 @@ df.eval("Bool=A>0.5", inplace=True)
 df.eval("BoolB=B>0.5", inplace=True)
 df.eval("BoolC=C>0.1", inplace=True)
 df["A"]=df["A"].round(3)
-df.loc[15]["A"] = math.nan
+df.loc[15, "A"] = math.nan
 df["B"]=df["B"].round(3)
 df["C"]=df["C"].round(3)
 df["D"]=df["D"].round(3)


### PR DESCRIPTION
This PR:
Fixes warning with pandas dataframes when a query parameter is provided to bokehDrawSA
Simplifies error bar logic, lowering file sizes in the process
Fixes a test in bokehDrawSA
Changes the base type to ColumnarDataSource for CDS types which have columns generated on the client - TODO: Add custom validation
Fixes #170 