### PR TITLE
Reduced widget description verbosity

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -1,11 +1,11 @@
-import {ColumnDataSource} from "models/sources/column_data_source"
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
 import * as p from "core/properties"
 
 export namespace DownsamplerCDS {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = ColumnDataSource.Props & {
-    source: p.Property<ColumnDataSource>
+  export type Props = ColumnarDataSource.Props & {
+    source: p.Property<ColumnarDataSource>
     nPoints: p.Property<number>
     selectedColumns: p.Property<string[]>
   }
@@ -13,7 +13,7 @@ export namespace DownsamplerCDS {
 
 export interface DownsamplerCDS extends DownsamplerCDS.Attrs {}
 
-export class DownsamplerCDS extends ColumnDataSource {
+export class DownsamplerCDS extends ColumnarDataSource {
   properties: DownsamplerCDS.Props
 
   constructor(attrs?: Partial<DownsamplerCDS.Attrs>) {
@@ -24,7 +24,7 @@ export class DownsamplerCDS extends ColumnDataSource {
 
   static init_DownsamplerCDS() {
     this.define<DownsamplerCDS.Props>(({Ref, Int, Array, String})=>({
-      source:  [Ref(ColumnDataSource)],
+      source:  [Ref(ColumnarDataSource)],
       nPoints:    [ Int, 300 ],
       selectedColumns:    [ Array(String), [] ]
     }))
@@ -38,6 +38,7 @@ export class DownsamplerCDS extends ColumnDataSource {
     super.initialize()
     this.booleans = null
     this._indices = []
+    this.data = {}
     this.shuffle_indices()
     this.update()
   }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import ColumnDataSource, ColorBar, HoverTool, VBar, HBar, Quad
 from bokeh.models.transforms import CustomJSTransform
@@ -1065,7 +1064,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
     return slider
 
 
-def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, default: int | str | None = None, **kwargs):
+def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, default, **kwargs):
     options = {'size': 10}
     options.update(kwargs)
     # optionsPlot = []

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1064,7 +1064,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
     return slider
 
 
-def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, default, **kwargs):
+def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, default=None, **kwargs):
     options = {'size': 10}
     options.update(kwargs)
     # optionsPlot = []

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -18,7 +18,6 @@ import numpy as np
 df = pd.DataFrame(np.random.random_sample(size=(200000, 6)), columns=list('ABCDEF'))
 
 parameterArray = [
-    {"name": "colorZ", "value":"A", "options":["A", "B"]},
     {"name": "size", "value":7, "range":[0, 30]},
     {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
     {"name": "paramX", "value":10, "range": [-20, 20]},
@@ -66,7 +65,8 @@ figureArray = [
     [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B'], {"size":"size"}],
     [['histoA.bin_center'], ['efficiency_A'], {"context":"histoA", "size":"size"}],
     [['histoA.bin_center'], ['histoA.entries', 'histoA.entries_C_cut'], {"context":"histoA", "size":"size"}],
-    [['histoAC.bin_center_0'], ['efficiency_AC'], {"context":"histoAC", "size":"size", "colorZvar": "histoAC.bin_center_1"}]
+    [['histoAC.bin_center_0'], ['efficiency_AC'], {"context":"histoAC", "size":"size", "colorZvar": "histoAC.bin_center_1"}],
+    {"size":"size", "legend_options": {"label_text_font_size": "legendFontSize"}}
 ]
 
 histoArray = [
@@ -97,17 +97,16 @@ widgetParams=[
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
-    ['select',["colorZ"], {"callback": "parameter", "default": 0}],
-    ['slider',["size"], {"callback": "parameter"}],
-    ['select',["legendFontSize"], {"callback": "parameter", "default": 2}],
-    ['slider',["C_cut"], {"callback": "parameter"}],
-    ['slider',["paramX"], {"callback": "parameter"}],
+    ['slider',["size"]],
+    ['select',["legendFontSize"]],
+    ['slider',["C_cut"]],
+    ['slider',["paramX"]],
 ]
 
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], {'sizing_mode': 'scale_width'}],
-    "Graphics": [[5, 6, 7], {'sizing_mode': 'scale_width'}],
-    "CustomJS functions": [[8, 9]]
+    "Graphics": [[5, 6], {'sizing_mode': 'scale_width'}],
+    "CustomJS functions": [[7, 8]]
     }
 
 figureLayoutDesc=[

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -42,7 +42,7 @@ widgetParams=[
     ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['multiSelect', ["DDC"]],
-    ['slider',["size"], {"callback": "parameter"}],
+    ['slider',["size"]],
   #  ['select',["CC", 0, 1, 2, 3]],
   #  ['multiSelect',["BoolB"]],
 ]
@@ -173,10 +173,11 @@ def testBokehClientHistogram3d_colormap():
         "range": [[0,1],[0,1],[0,1]]},
     ]
     figureArray = [
-        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size", "rescaleColorMapper": True }]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2" }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2" }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2" }],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2" }],
+        {"size": "size", "rescaleColorMapper": True}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -191,13 +192,14 @@ def testBokehClientHistogram3d_colormap_noscale():
     output_file("test_BokehClientHistogram_colormap_noscale.html")
     histoArray = [
         {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
-        "range": [[0,1],[0,1],[0,1]]},
+        "range": [[0,1],[0,1],[0,1]]}
     ]
     figureArray = [
-        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2"}],
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2"}],
+        {"size": "size"}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -79,9 +79,9 @@ widgetParams=[
     ['select',["CC", 0, 1, 2, 3], {"default": 1}],
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
-    ['select',["colorZ"], {"callback": "parameter"}],
-    ['slider',["size"], {"callback": "parameter"}],
-    ['select',["legendFontSize"], {"callback": "parameter"}],
+    ['select',["colorZ"]],
+    ['slider',["size"]],
+    ['select',["legendFontSize"]],
 ]
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8], {'sizing_mode': 'scale_width'}],
@@ -127,7 +127,7 @@ def testBokehDrawArraySA_tree():
 
 
 #testBokehDrawArraySA_tree()
-#testBokehDrawArrayWidget()               # OK
+testBokehDrawArrayWidget()               # OK
 #testBokehDrawArrayWidgetNoScale()
 #testBokehDrawArrayDownsample()
 #testBokehDrawArrayQuery()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -76,12 +76,12 @@ widgetParams=[
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10}],
     ['multiSelect', ["DDC"]],
-    ['select',["CC", 0, 1, 2, 3]],
+    ['select',["CC", 0, 1, 2, 3], {"default": 1}],
     ['multiSelect',["BoolB"]],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
-    ['select',["colorZ"], {"callback": "parameter", "default": 3}],
+    ['select',["colorZ"], {"callback": "parameter"}],
     ['slider',["size"], {"callback": "parameter"}],
-    ['select',["legendFontSize"], {"callback": "parameter", "default": 2}],
+    ['select',["legendFontSize"], {"callback": "parameter"}],
 ]
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8], {'sizing_mode': 'scale_width'}],


### PR DESCRIPTION
This PR:
Makes a non-breaking change to widget description array that makes the "default" and "callback" parameters optional by figuring the value out automatically
Refactors functions that make widgets by adding annotations
Adds a better error message for out of bounds default value with Select widgets
The default value of a Select widget can now also be specified as a string, in this case it uses the default value instead of the default index
Fixes a bug that was causing typescript compile errors
Relates to #171 