### PR TITLE
Clientside joins

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.py
@@ -1,4 +1,4 @@
-from bokeh.core.properties import Instance, String, Any, Dict
+from bokeh.core.properties import Instance, String, Any, Dict, Bool
 from bokeh.models import ColumnarDataSource
 
 
@@ -14,4 +14,5 @@ class CDSAlias(ColumnarDataSource):
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
     source=Instance(ColumnarDataSource, help="The source to draw from")
     mapping=Dict(String, Any, help="The mapping from new columns to old columns and possibly mappers")
+    includeOrigColumns=Bool
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -7,6 +7,7 @@ export namespace CDSAlias {
   export type Props = ColumnarDataSource.Props & {
     source: p.Property<ColumnarDataSource>
     mapping: p.Property<Record<string, any>>
+    includeOrigColumns: p.Property<boolean>
   }
 }
 
@@ -22,9 +23,10 @@ export class CDSAlias extends ColumnarDataSource {
   static __name__ = "CDSAlias"
 
   static init_CDSAlias() {
-    this.define<CDSAlias.Props>(({Ref})=>({
+    this.define<CDSAlias.Props>(({Ref, Boolean})=>({
       source:  [Ref(ColumnarDataSource)],
-      mapping:    [ p.Instance ]
+      mapping:    [ p.Instance ],
+      includeOrigColumns: [Boolean, true]
     }))
   }
 
@@ -52,11 +54,17 @@ export class CDSAlias extends ColumnarDataSource {
   }
 
   compute_functions(){
-    const {mapping, change, selected} = this
+    const {mapping, change, selected, source, data, includeOrigColumns} = this
     for (const key in mapping) {
       this.compute_function(key)
     }
-    selected.indices = this.source.selected.indices
+    if(includeOrigColumns)
+    for (const key in source.data) {
+      if(mapping[key] === undefined){
+        data[key] = source.get_array(key)
+      }
+    }
+    selected.indices = source.selected.indices
     change.emit()
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
@@ -16,5 +16,5 @@ class CDSJoin(ColumnarDataSource):
     right = Instance(ColumnarDataSource)
     on_left = List(String)
     on_right = List(String)
-    join_type = String
+    how = String(default="inner")
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
@@ -1,4 +1,4 @@
-from bokeh.core.properties import Instance, Any, List, String, Either, Dict
+from bokeh.core.properties import Instance, Any, List, String, Float
 from bokeh.models import ColumnarDataSource
 
 
@@ -17,4 +17,5 @@ class CDSJoin(ColumnarDataSource):
     on_left = List(String)
     on_right = List(String)
     how = String(default="inner")
+    tolerance = Float(default=1e-5)
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.py
@@ -1,0 +1,20 @@
+from bokeh.core.properties import Instance, Any, List, String, Either, Dict
+from bokeh.models import ColumnarDataSource
+
+
+class CDSJoin(ColumnarDataSource):
+    __implementation__ = "CDSJoin.ts"
+
+    # Below are all the "properties" for this model. Bokeh properties are
+    # class attributes that define the fields (and their types) that can be
+    # communicated automatically between Python and the browser. Properties
+    # also support type validation. More information about properties in
+    # can be found here:
+    #
+    #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
+    left = Instance(ColumnarDataSource)
+    right = Instance(ColumnarDataSource)
+    on_left = List(String)
+    on_right = List(String)
+    join_type = String
+    print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.ts
@@ -1,0 +1,113 @@
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
+import * as p from "core/properties"
+
+export namespace CDSJoin {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = ColumnarDataSource.Props & {
+    left: p.Property<ColumnarDataSource>
+    right: p.Property<ColumnarDataSource>
+    on_left: p.Property<string[]>
+    on_right: p.Property<string[]>
+    join_type: p.Property<string>
+  }
+}
+
+export interface CDSJoin extends CDSJoin.Attrs {}
+
+export class CDSJoin extends ColumnarDataSource {
+  properties: CDSJoin.Props
+
+  constructor(attrs?: Partial<CDSJoin.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "CDSJoin"
+
+  static init_CDSJoin() {
+    this.define<CDSJoin.Props>(({Ref, Array, String})=>({
+      left:  [Ref(ColumnarDataSource)],
+      right: [Ref(ColumnarDataSource)],
+      on_left: [ Array(String), [] ],
+      on_right: [ Array(String), [] ],
+      join_type: [ String ]
+    }))
+  }
+
+  _indices_left: number[] | null
+  _indices_right: number[] | null
+
+  initialize(){
+    super.initialize()
+    this.data = {}
+    this.compute_indices()
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+
+    this.connect(this.left.change, () => this.compute_indices())
+    this.connect(this.right.change, () => this.compute_indices())
+
+    //this.connect(this.selected.change, () => this.update_selection())
+  }
+
+  join_column(column: any[], indices: number[] | null): any[]{
+    if(indices === null){
+      return column
+    }
+    return indices.map(x => column[x])
+  }
+
+  compute_indices(): void{
+    const {left, right, on_left, on_right, join_type, change} = this
+    if (on_left.length === 0){
+      if (on_right.length === 0){
+        this._indices_left = null
+        this._indices_right = null
+      }
+    } else if(on_left.length === 1 && on_right.length === 0){
+      this._indices_left = null
+      this._indices_right = left.get_array(on_left[0])
+      if(this._indices_right === null){
+        console.warn("Cannot make join: column doesn't exist")
+        return
+      }
+      if (join_type == "inner" || join_type == "right"){
+        const l = right.get_length()
+        if (l !== null) this._indices_right = this._indices_right.filter(x => x > 0 && x < l)
+      }
+    } else if(on_left.length === 0 && on_right.length === 1){
+      this._indices_left = right.get_array(on_right[0])
+      this._indices_right = null
+      if(this._indices_left === null){
+        console.warn("Cannot make join: column doesn't exist")
+        return
+      }
+      if (join_type == "inner" || join_type == "left"){
+        const l = left.get_length()
+        if (l !== null) this._indices_left = this._indices_left.filter(x => x > 0 && x < l)
+      }
+    } else if (on_left.length != on_right.length){
+        console.warn("Cannot make join: incompatible numbers of columns")
+        return
+    } else {
+      // TODO: Make the logic for nontrivial joins
+    }
+    for (const key in left.data) {
+      const col = left.get_array(key)
+      if(col !== null) this.data[key] = this.join_column(col, this._indices_left)
+    }
+    for (const key in right.data) {
+      const col = right.get_array(key)
+      if(col !== null) this.data[key] = this.join_column(col, this._indices_right)
+    }
+    // selected.indices = this.source.selected.indices
+    change.emit()
+  }
+
+  /*update_selection(){
+    this.source.selected.indices = this.selected.indices
+  }*/
+
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSJoin.ts
@@ -9,7 +9,7 @@ export namespace CDSJoin {
     right: p.Property<ColumnarDataSource>
     on_left: p.Property<string[]>
     on_right: p.Property<string[]>
-    join_type: p.Property<string>
+    how: p.Property<string>
   }
 }
 
@@ -25,12 +25,12 @@ export class CDSJoin extends ColumnarDataSource {
   static __name__ = "CDSJoin"
 
   static init_CDSJoin() {
-    this.define<CDSJoin.Props>(({Ref, Array, String})=>({
+    this.define<CDSJoin.Props>(({Ref, Array, String, Number})=>({
       left:  [Ref(ColumnarDataSource)],
       right: [Ref(ColumnarDataSource)],
       on_left: [ Array(String), [] ],
       on_right: [ Array(String), [] ],
-      join_type: [ String ]
+      how: [ String ]
     }))
   }
 
@@ -60,7 +60,9 @@ export class CDSJoin extends ColumnarDataSource {
   }
 
   compute_indices(): void{
-    const {left, right, on_left, on_right, join_type, change} = this
+    const {left, right, on_left, on_right, how, change} = this
+    const is_left_join = how === "left" || how === "outer"
+    const is_right_join = how === "right" || how === "outer"
     if (on_left.length === 0){
       if (on_right.length === 0){
         this._indices_left = null
@@ -73,7 +75,7 @@ export class CDSJoin extends ColumnarDataSource {
         console.warn("Cannot make join: column doesn't exist")
         return
       }
-      if (join_type == "inner" || join_type == "right"){
+      if (!is_left_join){
         const l = right.get_length()
         if (l !== null) this._indices_right = this._indices_right.filter(x => x > 0 && x < l)
       }
@@ -84,7 +86,7 @@ export class CDSJoin extends ColumnarDataSource {
         console.warn("Cannot make join: column doesn't exist")
         return
       }
-      if (join_type == "inner" || join_type == "left"){
+      if (!is_right_join){
         const l = left.get_length()
         if (l !== null) this._indices_left = this._indices_left.filter(x => x > 0 && x < l)
       }
@@ -92,7 +94,74 @@ export class CDSJoin extends ColumnarDataSource {
         console.warn("Cannot make join: incompatible numbers of columns")
         return
     } else {
-      // TODO: Make the logic for nontrivial joins
+      // So far, we assume sorted keys
+      // Adding bisect and some way of avoiding invalidating indices would possibly help - or possibly using hash tables
+      // Something more elegant would also be easier to maintain
+      const len_left = left.length
+      const len_right = right.length
+      let down_left = 0
+      let down_right = 0
+      let indices_left = this._indices_left ?? []
+      indices_left.length = 0
+      let indices_right = this._indices_right ?? []
+      indices_right.length = 0
+      const arr_left: number[][] = on_left.map((x: string) => left.get_array(x))
+      const arr_right: number[][] = on_right.map((x: string) => right.get_array(x))
+      while(down_left < len_left && down_right < len_right){
+        const comparison_result = arr_left.reduceRight((acc: number, cur: number[], idx: number) => acc === 0 ? cur[down_left] - arr_right[idx][down_right] : acc, 0)
+        if(comparison_result > 0){
+          if(is_left_join){
+            indices_left.push(down_left)
+            indices_right.push(-1)
+          }
+          down_left ++
+        } else if(comparison_result < 0){
+          if(is_right_join){
+            indices_left.push(-1)
+            indices_right.push(down_right)
+          }
+          down_right ++
+        } else {
+          let up_left = down_left
+          let up_right = down_right
+          let is_greater = 0
+          while(is_greater === 0 && up_left < len_left){
+            up_left ++
+            is_greater = arr_left.reduceRight((acc: number, cur: number[]) => acc === 0 ? cur[up_left] - cur[down_left] : acc, 0)
+          }
+          is_greater = 0
+          while(is_greater === 0 && up_right < len_right){
+            up_right ++
+            is_greater = arr_right.reduceRight((acc: number, cur: number[]) => acc === 0 ? cur[up_right] - cur[down_right] : acc, 0)
+          }
+
+          for(let i_left = down_left; i_left < up_left; i_left ++){
+            for(let i_right = down_right; i_right < up_right; i_right ++){
+              indices_left.push(i_left)
+              indices_right.push(i_right)
+            }
+          }
+
+          down_left = up_left
+          down_right = up_right
+        }
+      }
+      if(is_left_join){
+        while(down_left < len_left){
+          indices_left.push(down_left)
+          indices_right.push(-1)
+          down_left ++   
+        }       
+      }
+      if(is_right_join){
+        while(down_right < len_right){
+          indices_left.push(-1)
+          indices_right.push(down_right) 
+          down_right ++         
+        }       
+      }
+      this._indices_left = indices_left
+      this._indices_right = indices_right
     }
     for (const key in left.data) {
       const col = left.get_array(key)
@@ -105,6 +174,7 @@ export class CDSJoin extends ColumnarDataSource {
     // selected.indices = this.source.selected.indices
     change.emit()
   }
+
 
   /*update_selection(){
     this.source.selected.indices = this.selected.indices

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -137,7 +137,8 @@ class bokehDrawSA(object):
             'nPointRender': 10000,
             "histogramArray": [],
             'parameterArray': [],
-            "aliasArray": []
+            "aliasArray": [],
+            "sourceArray": []
         }
         options.update(kwargs)
         kwargs=options
@@ -167,7 +168,7 @@ class bokehDrawSA(object):
         self = cls(dataFrame, query, "", "", "", "", None, variables=varList, **kwargs)
         if "arrayCompression" in options:
             self.isNotebook = False
-        dfQuery, _, _, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"],
+        dfQuery, _, _, _, _, _ = makeDerivedColumns(self.dataSource, figureArray=figureArray, histogramArray=options["histogramArray"] + options["sourceArray"],
                                               widgetArray=widgetsDescription, parameterArray=options["parameterArray"], 
                                               aliasArray=options["aliasArray"], options={"removeExtraColumns": True})
         self.figure, self.cdsSel, self.plotArray, dataFrameOrig, self.cmapList, self.cdsOrig, self.histoList,\

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1203,9 +1203,13 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
             left = histoDict[iHisto["left"]]["cds"]
             right = histoDict[iHisto["right"]]["cds"]
             on_left = []
+            if "left_on" in iHisto:
+                on_left = iHisto["left_on"]
             on_right = []
-            join_type = "inner"
-            cdsHisto = CDSJoin(left=left, right=right, on_left=on_left, on_right=on_right, join_type=join_type)
+            if "right_on" in iHisto:
+                on_right = iHisto["right_on"]
+            how  = "inner"
+            cdsHisto = CDSJoin(left=left, right=right, on_left=on_left, on_right=on_right, how=how)
             if iHisto["name"] in aliasDict:
                 mapping = aliasDict[iHisto["name"]]
                 mapping.update({"bin_center": "bin_center", "bin_count": "bin_count", "bin_bottom": "bin_bottom", "bin_top": "bin_top"})

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1245,7 +1245,10 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
             _, weights, cdsUsed = getOrMakeColumn(dfQuery, optionLocal["weights"], cdsUsed, aliasDict[""])
         if len(sampleVars) == 1:
             _, varNameX, cdsUsed = getOrMakeColumn(dfQuery, sampleVars[0], cdsUsed, aliasDict[""])
-            cdsHisto = HistogramCDS(source=cdsFull, nbins=optionLocal["nbins"], histograms=optionLocal["histograms"],
+            source = cdsFull
+            if "source" in iHisto:
+                source = iHisto["source"]
+            cdsHisto = HistogramCDS(source=source, nbins=optionLocal["nbins"], histograms=optionLocal["histograms"],
                                     range=optionLocal["range"], sample=varNameX, weights=weights)
             histoList.append(cdsHisto)
             if iHisto["name"] in aliasDict:
@@ -1261,7 +1264,10 @@ def bokehMakeHistogramCDS(dfQuery, cdsFull, histogramArray=[], histogramDict=Non
             for i in sampleVars:
                 _, varName, cdsUsed = getOrMakeColumn(dfQuery, i, cdsUsed, aliasDict[""])
                 sampleVarNames.append(varName)
-            cdsHisto = HistoNdCDS(source=cdsFull, nbins=optionLocal["nbins"],
+            source = cdsFull
+            if "source" in iHisto:
+                source = iHisto["source"]
+            cdsHisto = HistoNdCDS(source=source, nbins=optionLocal["nbins"],
                                     range=optionLocal["range"], sample_variables=sampleVarNames,
                                     weights=weights, histograms=optionLocal["histograms"])
             histoList.append(cdsHisto)
@@ -1364,12 +1370,10 @@ def makeDerivedColumns(dfQuery, figureArray=None, histogramArray=None, parameter
                         # TODO: Make error bars client side to get rid of this mess. At least ND histogram does support them.
                         if ('errY' in optionLocal) and (optionLocal['errY'] != ''):
                             dfQuery, varNameErrY = pandaGetOrMakeColumn(dfQuery, optionLocal['errY'])
-                            seriesErrY = dfQuery[varNameErrY]
                             columnNameDict[varNameErrY] = True
                             downsamplerColumns[varNameErrY] = True
                         if ('errX' in optionLocal) and (optionLocal['errX'] != ''):
                             dfQuery, varNameErrX = pandaGetOrMakeColumn(dfQuery, optionLocal['errX'])
-                            seriesErrX = dfQuery[varNameErrX]
                             columnNameDict[varNameErrX] = True
                             downsamplerColumns[varNameErrX] = True
                         if 'tooltips' in optionLocal:

--- a/RootInteractive/InteractiveDrawing/bokeh/test_ClientSideJoin.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_ClientSideJoin.py
@@ -1,0 +1,47 @@
+from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import bokehDrawSA
+from RootInteractive.InteractiveDrawing.bokeh.bokehTools import bokehDrawArray
+from RootInteractive.Tools.compressArray import arrayCompressionRelative16
+import numpy as np
+import pandas as pd
+from bokeh.plotting import output_file
+
+output_file("test_join.html")
+
+sourceArray = [
+    {
+        "name": "df2",
+        "data": pd.DataFrame({"A": [1,1,1,2,2,3,4]})
+    },
+    {
+        "name": "joinA",
+        "left": "df2",
+        "right": None,
+        "left_on": ["A"],
+        "right_on": ["A"]
+    },
+    {
+        "name": "histo0",
+        "variables": ["B"],
+        "weights": "A"
+    }
+]
+
+df = pd.DataFrame({"A": [1,2,2,2,4], "B": [1,2,3,4,5]})
+
+figureArray = [
+    [["A"], ["B"]],
+    [["joinA.A"], ["joinA.B"]],
+    [["histo0.bin_center"], ["histo0.bin_count"]]
+]
+
+widgetParams = [
+    ["multiSelect", ["A",1,2,3,4]]
+]
+
+figureLayout = [[0,1, {"height":200}], [2, {"height":50}], {"sizing_mode":"scale_width"}]
+widgetDesc = [[0]]
+def test_join():
+    output_file("test_join_inner.html")
+    bokehDrawSA.fromArray(df, None, figureArray, widgetParams, sourceArray=sourceArray, layout=figureLayout, widgetLayout=widgetDesc)
+
+test_join()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -233,7 +233,7 @@ def testJoin():
                 "sum_A": {"weights": "A"}
             }
         },
-        {"name": "histoB_join_histoAB_0", "left": "histoAB_0", "right":"histoB"}
+        {"name": "histoB_join_histoAB_0", "left": "histoAB_0", "right":"histoB", "left_on":["bin_center_1"], "right_on": ["bin_center"]}
     ]
     figureArray = [
         [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.mean', 'mean_A']],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -210,7 +210,49 @@ def testBokehClientHistogram3d_colormap_noscale():
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
+def testJoin():
+    output_file("test_BokehClientHistogramJoin.html")
+    aliasArray = [
+        {
+            "name": "mean_A",
+            "variables": ["sum_A", "bin_count"],
+            "func": "return sum_A / bin_count",
+            "context": "histoB"
+        },
+        {
+            "name": "delta_mean",
+            "variables": ["mean", "mean_A"],
+            "func": "return mean - mean_A",
+            "context": "histoB_join_histoAB_0"
+        }
+    ]
+    histoArray = [
+        {"name": "histoAB", "variables": ["A", "B"], "nbins": [10, 10], "axis": [0]},
+        {"name": "histoB", "variables": ["B"], "nbins": 10,
+            "histograms": {
+                "sum_A": {"weights": "A"}
+            }
+        },
+        {"name": "histoB_join_histoAB_0", "left": "histoAB_0", "right":"histoB"}
+    ]
+    figureArray = [
+        [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.mean', 'mean_A']],
+        [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.entries', 'histoB.bin_count']],
+        [['histoB_join_histoAB_0.bin_center_1'], ['histoB_join_histoAB_0.delta_mean']],
+        [['histoAB_0.bin_center_1'], ['histoAB_0.std']],
+        {"size": "size"}
+    ]
+    figureLayoutDesc=[
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
+    ]
+    
+    xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
+                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
+
 #testBokehClientHistogram3d()
 #testBokehClientHistogram()
 #testBokehClientHistogramOnlyHisto()
 #testBokehClientHistogramRowwiseTable()
+testJoin()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -1,9 +1,6 @@
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
 from RootInteractive.Tools.aliTreePlayer import *
 from bokeh.io import curdoc
-import os
-import sys
-import pytest
 from pandas import CategoricalDtype
 
 output_file("test_bokehClientHistogram.html")
@@ -214,15 +211,15 @@ def testJoin():
     output_file("test_BokehClientHistogramJoin.html")
     aliasArray = [
         {
-            "name": "mean_A",
+            "name": "unbinned_mean_A",
             "variables": ["sum_A", "bin_count"],
             "func": "return sum_A / bin_count",
             "context": "histoB"
         },
         {
             "name": "delta_mean",
-            "variables": ["mean", "mean_A"],
-            "func": "return mean - mean_A",
+            "variables": ["mean", "unbinned_mean_A"],
+            "func": "return mean - unbinned_mean_A",
             "context": "histoB_join_histoAB_0"
         }
     ]
@@ -232,27 +229,25 @@ def testJoin():
             "histograms": {
                 "sum_A": {"weights": "A"}
             }
-        },
+        }
+    ]
+    sourceArray = [
         {"name": "histoB_join_histoAB_0", "left": "histoAB_0", "right":"histoB", "left_on":["bin_center_1"], "right_on": ["bin_center"]}
     ]
     figureArray = [
-        [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.mean', 'mean_A']],
+        [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.mean', 'unbinned_mean_A']],
         [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.entries', 'histoB.bin_count']],
         [['histoB_join_histoAB_0.bin_center_1'], ['histoB_join_histoAB_0.delta_mean']],
         [['histoAB_0.bin_center_1'], ['histoAB_0.std']],
         {"size": "size"}
     ]
     figureLayoutDesc=[
-        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
-        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
-                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
+                              widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, sourceArray=sourceArray, aliasArray=aliasArray)
 
-#testBokehClientHistogram3d()
-#testBokehClientHistogram()
-#testBokehClientHistogramOnlyHisto()
-#testBokehClientHistogramRowwiseTable()
 testJoin()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -47,7 +47,7 @@ df.head(10)
 df.meta.metaData = {'A.AxisTitle': "A (cm)", 'B.AxisTitle': "B (cm/s)", 'C.AxisTitle': "C (s)", 'D.AxisTitle': "D (a.u.)", 'Bool.AxisTitle': "A>half", 'E.AxisTitle': "Category"}
 
 parameterArray = [
-    {"name": "colorZ", "value":"EE", "options":["A", "B", "DD", "EE"]},
+    {"name": "colorZ", "value":"EE", "options":["A", "B", "EE"]},
     {"name": "size", "value":7, "range":[0, 30]},
     {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
 ]
@@ -57,7 +57,7 @@ figureArray = [
     [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "varZ": "C", "errY": "errY", "errX":"0.01"}],
     [['A'], ['C+A', 'C-A', 'A/A']],
     [['B'], ['C+B', 'C-B'], { "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True}],
-    [['D'], ['(A+B+C)*D'], {"colorZvar": "colorZ", "size": 10, "errY": "errY"} ],
+    [['D'], ['(A+B+C)*DD'], {"colorZvar": "colorZ", "size": 10, "errY": "errY"} ],
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
     [['D'], ['D*10'], {"size": 10, "errY": "errY"}],

--- a/RootInteractive/Tools/pandaTools.py
+++ b/RootInteractive/Tools/pandaTools.py
@@ -39,7 +39,7 @@ def pandaGetOrMakeColumn(df, variableName):
     varName = re.sub(r"""\.""", "_Dot_", varName)
     varName = re.sub(r"""@""", "_At_", varName)
     varName = re.sub(r"""(\(|\))""", "_", varName)
-    if variableName in df.columns:
+    if varName in df.columns:
         return df, varName
     expression = variableName
     df.meta.metaData[varName + ".OrigName"] = variableName


### PR DESCRIPTION
This pull request adds:

New parameter to bokehDrawArray - sourceArray

Outside of specifying histograms as in histoArray, it also allows specifying secondary data sources and joins on the client

Do not merge yet, case when histograms use sources different from primary CDS is broken, taking variables from secondary sources derived on server doesn't work either.

Use case:
```
df2 = pd.DataFrame(...)
sourceArray = [
  {"name": "df2", "data": df2},
  {"name": "join_df2", "left": None, "right":"df2", "left_on": ["bin_index"], "right_on": ["bin_index"], "how": "left"}
]
```