### PR TITLE
Fixed error handling of nonexisting columns

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -36,7 +36,7 @@ bokehMarkers = ["square", "circle", "triangle", "diamond", "square_cross", "circ
 
 # default tooltips for 1D and 2D histograms
 defaultHistoTooltips = [
-    ("range", "[@{bin_left}, @{bin_right}]"),
+    ("range", "[@{bin_bottom}, @{bin_top}]"),
     ("count", "@bin_count")
 ]
 
@@ -1136,9 +1136,9 @@ def addHistogramGlyph(fig, histoHandle, marker, colorHisto, size, options):
         visualization_type = options["visualization_type"]
     if visualization_type == "bars":
         if options['flip_histogram_axes']:
-            histoGlyph = Quad(left=0, right="bin_count", bottom="bin_left", top="bin_right", fill_color=colorHisto)
+            histoGlyph = Quad(left=0, right="bin_count", bottom="bin_bottom", top="bin_top", fill_color=colorHisto)
         else:
-            histoGlyph = Quad(left="bin_left", right="bin_right", bottom=0, top="bin_count", fill_color=colorHisto)
+            histoGlyph = Quad(left="bin_bottom", right="bin_top", bottom=0, top="bin_count", fill_color=colorHisto)
         histoGlyphRenderer = fig.add_glyph(cdsHisto, histoGlyph)
     elif visualization_type == "points":
         if options['flip_histogram_axes']:

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -260,6 +260,10 @@ def getOrMakeColumns(variableNames, context = None, cdsDict: dict = {}, paramDic
     for i in range(max(len(variableNames), len(context))):
         i_var = variableNames[i % nvars]
         i_context = context[i % n_context] 
+        if i_context == "$IGNORE":
+            variables.append(None)
+            ctx_updated.append(i_context)
+            continue
         if i_context in memoizedColumns and i_var in memoizedColumns[i_context]:
             variables.append(memoizedColumns[i_context][i_var])
             ctx_updated.append(i_context)

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -199,7 +199,7 @@ class ColumnEvaluator:
             self.dependencies.add((histogram["source"], histogram["histograms"][id]["weights"]))
         isOK = (id == "bin_count")
         if self.cdsDict[self.context]["type"] == "histogram":
-            if id in ["bin_left", "bin_center", "bin_right"]:
+            if id in ["bin_bottom", "bin_center", "bin_top"]:
                 isOK = True
         else:
             if id in ["bin_bottom_{}".format(i) for i in range(len(histogram["variables"]))]:
@@ -207,7 +207,7 @@ class ColumnEvaluator:
             if id in ["bin_center_{}".format(i) for i in range(len(histogram["variables"]))]:
                 isOK = True
             if id in ["bin_top_{}".format(i) for i in range(len(histogram["variables"]))]:
-                isOK = True            
+                isOK = True         
         if "histograms" in histogram and id in histogram["histograms"]:
             isOK = True
         if not isOK:


### PR DESCRIPTION
This PR should fix #205 by raising a KeyError when an invalid column is used from a histogram.

However, a bug was discovered in joins when making the changes - columns in joins with implicit sources aren't added to the dependency tree - the fix for that bug is more complex, and the bug has a workaround by chaining table names with a dot, so it will probably be implemented in a later PR.

Possibly also fixes #121 by fixing inconsistent usage of "edges" between 1D and ND