### PR TITLE
Optimized the MultiSelect widget selection

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
@@ -1,0 +1,15 @@
+from bokeh.model import Model
+from bokeh.core.properties import Instance, String, Dict, List, Any, Int
+from bokeh.models.widgets import MultiSelect
+from bokeh.models.sources import ColumnarDataSource
+
+class MultiSelectFilter(Model):
+    __implementation__ = "MultiSelectFilter.ts"
+
+    source = Instance(ColumnarDataSource, help="Column data source to select from")
+    widget = Instance(MultiSelect, help="MultiSelect controlling the filter")
+    mapping = Dict(String, Int, help="Dictionary converting labels to values to use")
+    mask = Int(default=-1, help="AND mask to apply before using multiselect")
+    field = String(help="The field to check")
+    how = String(default="any", help="The operation to use for bitmask - supportedo ptions so far are any and all")
+

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -1,0 +1,69 @@
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
+import { MultiSelect } from "models/widgets/multiselect"
+import {Model} from "model"
+import * as p from "core/properties"
+
+export namespace MultiSelectFilter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    source: p.Property<ColumnarDataSource>
+    widget: p.Property<MultiSelect>
+    mapping: p.Property<Record<string, number>>
+    mask: p.Property<number>
+    field:p.Property<string>
+    how: p.Property<string>
+  }
+}
+
+export interface MultiSelectFilter extends MultiSelectFilter.Attrs {}
+
+export class MultiSelectFilter extends Model {
+  properties: MultiSelectFilter.Props
+
+  constructor(attrs?: Partial<MultiSelectFilter.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "MultiSelectFilter"
+
+  static init_MultiSelectFilter() {
+    this.define<MultiSelectFilter.Props>(({Ref, Int, String})=>({
+      source:  [Ref(ColumnarDataSource)],
+      widget:    [ Ref(MultiSelect) ],
+      mapping:    [p.Instance],
+      mask: [Int, -1],
+      field: [String],
+      how: [String, "any"]
+    }))
+  }
+
+  private cached_vector: boolean[]
+  private dirty_source: boolean
+  private dirty_widget: boolean
+
+  initialize(){
+    super.initialize()
+    this.dirty_source = true
+    this.dirty_widget = true
+  }
+
+  public v_compute(): boolean[]{
+    const {dirty_source, dirty_widget, cached_vector, widget, source, mapping, mask, field, how} = this
+    if (!dirty_source && !dirty_widget){
+        return cached_vector
+    }
+    let col = source.get_array(field)
+    const mask_new = widget.value.map((a: string) => mapping[a]).reduce((acc: number, cur: number) => acc | cur, mask)
+    let new_vector: boolean[] = []
+    if (how == "any"){
+        new_vector = col.map((x: number) => (x & mask_new) != 0)
+    } else if(how == "all"){
+        new_vector = col.map((x:number) => (x & mask_new) == mask_new)
+    }
+    this.dirty_source = false
+    this.dirty_widget = false
+    this.cached_vector = new_vector
+    return new_vector
+  }
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -97,9 +97,15 @@ export class MultiSelectFilter extends Model {
     }
     const mask_new = widget.value.map((a: string) => mapping[a]).reduce((acc: number, cur: number) => acc | cur, 0) & mask
     if (how == "any"){
-        new_vector = col.map((x: number) => (x & mask_new) != 0)
+        for(let i=0; i<col.length; i++){
+          const x = col[i] as number
+          new_vector[i] = (x & mask_new) != 0
+        }
     } else if(how == "all"){
-        new_vector = col.map((x:number) => (x & mask_new) == mask_new)
+      for(let i=0; i<col.length; i++){
+        const x = col[i] as number
+        new_vector[i] = (x & mask_new) == mask_new
+      }
     }
     this.dirty_source = false
     this.dirty_widget = false

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -48,14 +48,30 @@ export class MultiSelectFilter extends Model {
     this.dirty_widget = true
   }
 
+  connect_signals(): void {
+    super.connect_signals()
+
+    this.connect(this.widget.properties.value.change, this.mark_dirty_widget)
+    this.connect(this.source.change, this.mark_dirty_source)
+  }
+
+  mark_dirty_widget(){
+    this.dirty_widget = true
+  }
+
+  mark_dirty_source(){
+    this.dirty_source = true
+  }
+
   public v_compute(): boolean[]{
     const {dirty_source, dirty_widget, cached_vector, widget, source, mapping, mask, field, how} = this
     if (!dirty_source && !dirty_widget){
         return cached_vector
     }
     let col = source.get_array(field)
-    const mask_new = widget.value.map((a: string) => mapping[a]).reduce((acc: number, cur: number) => acc | cur, mask)
-    let new_vector: boolean[] = []
+    const mask_new = widget.value.map((a: string) => mapping[a]).reduce((acc: number, cur: number) => acc | cur, 0) & mask
+    let new_vector: boolean[]
+     = []
     if (how == "any"){
         new_vector = col.map((x: number) => (x & mask_new) != 0)
     } else if(how == "all"){

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -79,7 +79,8 @@ export class MultiSelectFilter extends Model {
         const accepted_codes = widget.value.map((a: string) => mapping[a])
         let count=0
         for(let i=0; i<col.length; i++){
-            let isOK = accepted_codes.reduce((acc: boolean, cur: number)=>acc||cur == col[i],false)
+            const x = col[i]
+            let isOK = accepted_codes.reduce((acc: boolean, cur: number)=>acc||(cur == x),false)
             new_vector[i] = isOK
         }        
         console.log(count)

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -69,9 +69,26 @@ export class MultiSelectFilter extends Model {
         return cached_vector
     }
     let col = source.get_array(field)
+    let new_vector: boolean[] = this.cached_vector
+    if (new_vector == null){
+        new_vector = Array(col.length)
+    } else {
+        new_vector.length = col.length
+    }
+    if (how == "whitelist"){
+        const accepted_codes = widget.value.map((a: string) => mapping[a])
+        let count=0
+        for(let i=0; i<col.length; i++){
+            let isOK = accepted_codes.reduce((acc: boolean, cur: number)=>acc||cur == col[i],false)
+            new_vector[i] = isOK
+        }        
+        console.log(count)
+        this.dirty_source = false
+        this.dirty_widget = false
+        this.cached_vector = new_vector
+        return new_vector
+    }
     const mask_new = widget.value.map((a: string) => mapping[a]).reduce((acc: number, cur: number) => acc | cur, 0) & mask
-    let new_vector: boolean[]
-     = []
     if (how == "any"){
         new_vector = col.map((x: number) => (x & mask_new) != 0)
     } else if(how == "all"){

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -80,7 +80,13 @@ export class MultiSelectFilter extends Model {
         let count=0
         for(let i=0; i<col.length; i++){
             const x = col[i]
-            let isOK = accepted_codes.reduce((acc: boolean, cur: number)=>acc||(cur == x),false)
+            let isOK = false
+            for(let j=0; j<accepted_codes.length; j++){
+              if(accepted_codes[j] == x){
+                isOK = true
+                break
+              }
+            }
             new_vector[i] = isOK
         }        
         console.log(count)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -760,8 +760,9 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 localWidget = makeBokehSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
             if variables[0] == 'multiSelect':
                 localWidget, widgetFilter, newColumn = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
-                memoized_columns[None][newColumn["name"]] = newColumn
-                sources.add((None, newColumn["name"]))
+                if newColumn is not None:
+                    memoized_columns[None][newColumn["name"]] = newColumn
+                    sources.add((None, newColumn["name"]))
             if variables[0] == 'multiSelectBitmask':
                 localWidget, widgetFilter = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
             if variables[0] == 'toggle':
@@ -1305,14 +1306,17 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
         optionsPlot = params[1:]
     for i, val in enumerate(optionsPlot):
         optionsPlot[i] = str((val))
-    mapping = {}
-    for i, val in enumerate(optionsPlot):
-        mapping[val] = i
-    # print(optionsPlot)
-    how="any"
     widget_local = MultiSelect(title=params[0], value=optionsPlot, options=optionsPlot, size=options['size'])
-    filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how=how, mapping=mapping)
-    newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes}
+    filterLocal = None
+    newColumn = None
+    if len(optionsPlot) < 31:
+        mapping = {}
+        for i, val in enumerate(optionsPlot):
+            mapping[val] = 2**i
+        # print(optionsPlot)
+        how="any"
+        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how=how, mapping=mapping)
+        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": 2**codes}
     return widget_local, filterLocal, newColumn
 
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,3 +1,4 @@
+from bisect import bisect
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import ColumnDataSource, ColorBar, HoverTool, VBar, HBar, Quad
 from bokeh.models.transforms import CustomJSTransform
@@ -1302,12 +1303,12 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
     options = {'default': 0, 'size': 4}
     options.update(kwargs)
     # optionsPlot = []
-    if len(params) == 1:
-        codes, optionsPlot = pd.factorize(df[params[0]], sort=True)
-        optionsPlot = optionsPlot.to_list()
+    if len(params) > 1:
+        dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
     else:
-        optionsPlot = params[1:]
-        codes = np.searchsorted(optionsPlot, df[params[0]])
+        dfCategorical = df[params[0]]
+    codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
+    optionsPlot = optionsPlot.to_list()
     for i, val in enumerate(optionsPlot):
         optionsPlot[i] = str((val))
     widget_local = MultiSelect(title=params[0], value=optionsPlot, options=optionsPlot, size=options['size'])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1318,7 +1318,7 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
             mapping[val] = 2**i
         # print(optionsPlot)
         filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="any", mapping=mapping)
-        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": 2**codes}
+        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": (2**codes).astype(np.int32)}
     else:
         mapping = {}
         for i, val in enumerate(optionsPlot):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1317,9 +1317,15 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
         for i, val in enumerate(optionsPlot):
             mapping[val] = 2**i
         # print(optionsPlot)
-        how="any"
-        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how=how, mapping=mapping)
+        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="any", mapping=mapping)
         newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": 2**codes}
+    else:
+        mapping = {}
+        for i, val in enumerate(optionsPlot):
+            mapping[val] = i
+        print(len(optionsPlot))
+        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="whitelist", mapping=mapping)
+        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes}
     return widget_local, filterLocal, newColumn
 
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1325,7 +1325,7 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
             mapping[val] = i
         print(len(optionsPlot))
         filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="whitelist", mapping=mapping)
-        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes}
+        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes.astype(np.int32)}
     return widget_local, filterLocal, newColumn
 
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -74,6 +74,9 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     let indicesAll = [];
     for (const iWidget of widgetList){
         if(iWidget.filter != null){
+            if (this == iWidget.widget){
+                iWidget.filter.dirty_widget = true
+            }
             const widgetFilter = iWidget.filter.v_compute();
             for(let i=0; i<size; i++){
                 isSelected[i] &= widgetFilter[i];

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -25,6 +25,7 @@ from RootInteractive.InteractiveDrawing.bokeh.DownsamplerCDS import DownsamplerC
 from RootInteractive.InteractiveDrawing.bokeh.CDSAlias import CDSAlias
 from RootInteractive.InteractiveDrawing.bokeh.CustomJSNAryFunction import CustomJSNAryFunction
 from RootInteractive.InteractiveDrawing.bokeh.CDSJoin import CDSJoin
+from RootInteractive.InteractiveDrawing.bokeh.MultiSelectFilter import MultiSelectFilter
 import numpy as np
 import pandas as pd
 import re
@@ -72,6 +73,13 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     let permutationFilter = [];
     let indicesAll = [];
     for (const iWidget of widgetList){
+        if(iWidget.filter != null){
+            const widgetFilter = iWidget.filter.v_compute();
+            for(let i=0; i<size; i++){
+                isSelected[i] &= widgetFilter[i];
+            }
+            continue;
+        }
         const widget = iWidget.widget;
         const widgetType = iWidget.type;
         const col = iWidget.key && cdsOrig.get_column(iWidget.key);
@@ -730,6 +738,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if len(variables) == 3:
                 optionWidget = variables[2].copy()
             fakeDf = None
+            widgetFilter = None
             if "callback" not in optionLocal:
                 if variables[1][0] in paramDict:
                     optionWidget["callback"] = "parameter"
@@ -750,7 +759,11 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if variables[0] == 'select':
                 localWidget = makeBokehSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
             if variables[0] == 'multiSelect':
-                localWidget = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
+                localWidget, widgetFilter, newColumn = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
+                memoized_columns[None][newColumn["name"]] = newColumn
+                sources.add((None, newColumn["name"]))
+            if variables[0] == 'multiSelectBitmask':
+                localWidget, widgetFilter = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
             if variables[0] == 'toggle':
                 label = variables[1][0]
                 if "label" in optionWidget:
@@ -767,7 +780,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 cds_used = cds_names[0]
                 if cds_used not in widgetDict:
                     widgetDict[cds_used] = []
-                widgetDict[cds_used].append({"widget": localWidget, "type": variables[0], "key": varName})
+                widgetDictLocal = {"widget": localWidget, "type": variables[0], "key": varName}
+                if widgetFilter is not None:
+                    widgetDictLocal["filter"] = widgetFilter
+                widgetDict[cds_used].append(widgetDictLocal)
             continue
         if variables[0] == "textQuery":
             optionWidget = {}
@@ -1082,6 +1098,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                                     cdsHistoSummary=cdsHistoSummary, profileList=profileList, aliasDict=list(aliasDict.values()))
         for iWidget in widgetList:
             iWidget["widget"].js_on_change("value", callback)
+            if "filter" in iWidget:
+                iWidget["filter"].source = cdsFull
     connectWidgetCallbacks(widgetParams, widgetArray, paramDict, None)
     if isinstance(options['layout'], list) or isinstance(options['layout'], dict):
         pAll = processBokehLayoutArray(options['layout'], plotArray)
@@ -1281,16 +1299,21 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
     options.update(kwargs)
     # optionsPlot = []
     if len(params) == 1:
-        try:
-            optionsPlot = np.sort(df[params[0]].unique()).tolist()
-        except:
-            optionsPlot = sorted(df[params[0]].dropna().unique().tolist())
+        codes, optionsPlot = pd.factorize(df[params[0]], sort=True)
+        optionsPlot = optionsPlot.to_list()
     else:
         optionsPlot = params[1:]
     for i, val in enumerate(optionsPlot):
         optionsPlot[i] = str((val))
+    mapping = {}
+    for i, val in enumerate(optionsPlot):
+        mapping[val] = i
     # print(optionsPlot)
-    return MultiSelect(title=params[0], value=optionsPlot, options=optionsPlot, size=options['size'])
+    how="any"
+    widget_local = MultiSelect(title=params[0], value=optionsPlot, options=optionsPlot, size=options['size'])
+    filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how=how, mapping=mapping)
+    newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes}
+    return widget_local, filterLocal, newColumn
 
 
 def makeBokehCheckboxWidget(df: pd.DataFrame, params: list, paramDict: dict, **kwargs):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1307,6 +1307,7 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
         optionsPlot = optionsPlot.to_list()
     else:
         optionsPlot = params[1:]
+        codes = np.searchsorted(optionsPlot, df[params[0]])
     for i, val in enumerate(optionsPlot):
         optionsPlot[i] = str((val))
     widget_local = MultiSelect(title=params[0], value=optionsPlot, options=optionsPlot, size=options['size'])

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -34,7 +34,7 @@ widgetParams = [
     ['range', ['A', -1., 1., 0.1, -1., 1.]],
     ['range', ['B']],
     ['range', ['C']],
-    ['range', ['D']],
+    ['multiSelect', ['D']],
 ]
 widgetLayoutDesc = [[0, 1], [2, 3], {'sizing_mode': 'scale_width'}]
 
@@ -58,3 +58,5 @@ def test_clientHistogramWeightCompressed():
     xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histogramArray,
                                 arrayCompression=arrayCompressionRelative16)
+
+test_clientHistogramWeightCompressed()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -58,5 +58,3 @@ def test_clientHistogramWeightCompressed():
     xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histogramArray,
                                 arrayCompression=arrayCompressionRelative16)
-
-test_clientHistogramWeightCompressed()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -149,5 +149,5 @@ def testBokehDrawArraySA_tree():
     if "ROOT" not in sys.modules:
         pytest.skip("no ROOT module")
     output_file("test_bokehDrawSAArray_fromTTree.html")
-    fig=bokehDrawSA.fromArray(tree, "A>0", figureArray, widgets, tooltips=tooltips, layout=figureLayout)
+    fig=bokehDrawSA.fromArray(tree, "A>0", figureArray, widgets, tooltips=tooltips, layout=figureLayoutDesc)
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -80,7 +80,7 @@ widgetParams=[
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10}],
-    ['multiSelect', ["DDC"]],
+    ['multiSelect', ["DDC", "A2", "A3", "A4", "A0", "A1"]],
     ['select',["CC", 0, 1, 2, 3], {"default": 1}],
     ['multiSelect',["BoolB"]],
     ['textQuery', {"title": "selection"}],

--- a/RootInteractive/Tools/compressArray.py
+++ b/RootInteractive/Tools/compressArray.py
@@ -3,7 +3,7 @@ import pickle
 import zlib
 from bokeh.util.serialization import *
 import numpy as np
-import pandas as pdMap
+import pandas as pd
 import sys
 import re
 import collections
@@ -140,8 +140,10 @@ def compressArray(inputArray, actionArray, keepValues=False):
             if action == "delta":
                 currentArray = roundAbsolute(currentArray, actionParam)
             if action == "zip":
-                arrayInfo["dtype"] = currentArray.to_numpy().dtype.name
-                currentArray = zlib.compress(currentArray.to_numpy())
+                if isinstance(currentArray, pd.Series):
+                    currentArray = currentArray.to_numpy()
+                arrayInfo["dtype"] = currentArray.dtype.name
+                currentArray = zlib.compress(currentArray)
             if action == "unzip":
                 currentArray = np.frombuffer(zlib.decompress(currentArray),dtype=arrayInfo["dtype"])
             if action == "base64":
@@ -170,7 +172,7 @@ def compressArray(inputArray, actionArray, keepValues=False):
                     currentArray = currentArray.map(dictValues).astype("int32")
             if action == "decode":
                 if not arrayInfo["skipCode"]:
-                    arrayAsPanda=pdMap.Series(currentArray)      # TODO - numpy does not have map function better solution to fine
+                    arrayAsPanda=pd.Series(currentArray)      # TODO - numpy does not have map function better solution to fine
                     currentArray = arrayAsPanda.map(arrayInfo["valueCode"])
             counter+=1
        # except:


### PR DESCRIPTION
Should fix #210, also creates infrastructure for #193

This PR:
- Fixes a bug with compression causing it to only work with Pandas Series
- Adds caching of results for MultiSelect widgets
- Optimizes comparison for MultiSelect by replacing the reduce() with a for loop
- Optimizes it further by using bitmasks if the number of categories is not too large and fits within a 32-bit integer

TODO:
-Add the python function that makes a BitmaskMultiSelect widget