### PR TITLE
Widgets in layoutDesc can be found by names

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -74,7 +74,7 @@ export class CDSAlias extends ColumnarDataSource {
     if(column == null){
       let new_column = source.get_column(columnName)
       if(new_column == null){
-        throw ReferenceError("Column not defined: "+ columnName)
+        throw ReferenceError("Column not defined: "+ columnName + " in data source " + source.name)
       }
       else if (!Array.isArray(new_column)){
         data[columnName] = Array.from(new_column)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehDrawSA.py
@@ -98,6 +98,7 @@ class bokehDrawSA(object):
         self.profileList = None
         self.paramDict = None
         self.aliasDict = None
+        self.plotDict = None
 
     @classmethod
     def fromArray(cls, dataFrame, query, figureArray, widgetsDescription, **kwargs):
@@ -170,11 +171,11 @@ class bokehDrawSA(object):
             self.isNotebook = False
         mergedFigureArray = figureArray + widgetsDescription
         self.figure, self.cdsSel, self.plotArray, self.cmapList, self.cdsOrig, self.histoList,\
-            self.cdsHistoSummary, self.profileList, self.paramDict, self.aliasDict = bokehDrawArray(self.dataSource, None, mergedFigureArray, **kwargs)
+            self.cdsHistoSummary, self.profileList, self.paramDict, self.aliasDict, self.plotDict = bokehDrawArray(self.dataSource, None, mergedFigureArray, **kwargs)
         # self.cdsOrig=ColumnDataSource(dataFrameOrig)
         #self.Widgets = self.initWidgets(widgetString)
         if isinstance(self.widgetLayout, list) or isinstance(self.widgetLayout, dict):
-            widgetList=processBokehLayoutArray(self.widgetLayout, self.plotArray[nFigures:])
+            widgetList=processBokehLayoutArray(self.widgetLayout, self.plotArray[nFigures:], self.plotDict)
         self.pAll=gridplotRow([self.figure, widgetList], sizing_mode=self.options['sizing_mode'])
         self.widgetList=widgetList
         #self.pAll=column([self.figure,widgetList],sizing_mode=self.options['sizing_mode'])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -788,8 +788,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     active = paramDict[variables[1][0]]["value"]
                 localWidget = Toggle(label=label, active=active)
             plotArray.append(localWidget)
-            if "name" in optionLocal:
-                plotDict[optionLocal["name"]] = localWidget
+            if "name" in optionWidget:
+                plotDict[optionWidget["name"]] = localWidget
             if localWidget and optionWidget["callback"] != "selection":
                 widgetArray.append(localWidget)
                 widgetParams.append(variables)
@@ -1130,7 +1130,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         pAll = processBokehLayoutArray(options['layout'], plotArray, plotDict)
     if options['doDraw']:
         show(pAll)
-    return pAll, cdsDict[None]["cds"], plotArray, colorMapperDict, cdsDict[None]["cdsOrig"], histoList, cdsHistoSummary, profileList, paramDict, aliasDict
+    return pAll, cdsDict[None]["cds"], plotArray, colorMapperDict, cdsDict[None]["cdsOrig"], histoList, cdsHistoSummary, profileList, paramDict, aliasDict, plotDict
 
 
 def addHisto2dGlyph(fig, histoHandle, marker, options):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1164,7 +1164,7 @@ def addHisto2dGlyph(fig, histoHandle, marker, options):
         color_bar = ColorBar(color_mapper=mapperC['transform'], width=8, location=(0, 0),
                              title="Count")
         histoGlyph = Quad(left="bin_bottom_0", right="bin_top_0", bottom="bin_bottom_1", top="bin_top_1",
-                          fill_color=mapperC)
+                          fill_color=mapperC, line_width=0)
         histoGlyphRenderer = fig.add_glyph(cdsHisto, histoGlyph)
         fig.add_layout(color_bar, 'right')
     elif visualization_type == "colZ":

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -117,14 +117,14 @@ def test_record(record_property: ty.Callable[[str, ty.Any], None]):
 
 def testBokehDrawArrayWidget(record_property: ty.Callable[[str, ty.Any], None]):
     output_file("test_BokehDrawArrayWidget.html")
-    fig=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", parameterArray=parameterArray)
+    fig=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", parameterArray=parameterArray, nPointRender="nPoints")
     record_property("html_size",os.stat("test_BokehDrawArrayWidget.html").st_size)
     record_property("cdsOrig_size",len(fig.cdsOrig.column_names))
 
 
 def testBokehDrawArrayWidgetNoScale(record_property: ty.Callable[[str, ty.Any], None]):
     output_file("test_BokehDrawArrayWidgetNoScale.html")
-    fig=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None, parameterArray=parameterArray)
+    fig=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips,widgetLayout=widgetLayoutDesc,sizing_mode=None, parameterArray=parameterArray, nPointRender="nPoints")
     record_property("html_size",os.stat("test_BokehDrawArrayWidgetNoScale.html").st_size)
     record_property("cdsOrig_size",len(fig.cdsOrig.column_names))
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -96,9 +96,10 @@ widgetParams=[
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
 
 ]
+
 widgetLayoutDesc={
-    "Selection": [[6, 7, 8], [9, 10, 11], [12, 13],[14, 15, 16], {'sizing_mode': 'scale_width'}],
-    "Graphics": [[0, 1, 2], [3, 4, 5], {'sizing_mode': 'scale_width'}]
+    "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8, 9], {'sizing_mode': 'scale_width'}],
+    "Graphics": [["colorZ", 11, 12], [13, 14, 15], {'sizing_mode': 'scale_width'}]
     }
 
 figureLayoutDesc={
@@ -155,3 +156,5 @@ def testBokehDrawArraySA_tree():
     output_file("test_bokehDrawSAArray_fromTTree.html")
     fig=bokehDrawSA.fromArray(tree, "A>0", figureArray, widgets, tooltips=tooltips, layout=figureLayoutDesc)
 
+output_file("test_BokehDrawArrayWidget.html")
+bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", parameterArray=parameterArray)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -74,13 +74,6 @@ widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1
 tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)"), ("ErrY", "@errY")]
 
 widgetParams=[
-    ['select',["colorZ"]],
-    ['select',["X"]],
-    ['slider',["size"]],
-    ['select',["legendFontSize"]],
-    ['toggle', ['legendVisible']],
-    ['slider', ['nPoints']],
-
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1]],
 
@@ -94,12 +87,17 @@ widgetParams=[
     ['multiSelect',["BoolB"]],
     ['textQuery', {"title": "selection"}],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
-
+    ['select',["colorZ"], {"name": "colorZ"}],
+    ['select',["X"], {"name": "X"}],
+    ['slider',["size"], {"name": "markerSize"}],
+    ['select',["legendFontSize"], {"name": "legendFontSize"}],
+    ['toggle', ['legendVisible'], {"name": "legendVisible"}],
+    ['slider', ['nPoints'], {"name": "nPointsRender"}]
 ]
 
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8, 9], {'sizing_mode': 'scale_width'}],
-    "Graphics": [["colorZ", 11, 12], [13, 14, 15], {'sizing_mode': 'scale_width'}]
+    "Graphics": [["colorZ", "X", "markerSize"], ["legendFontSize", "legendVisible", "nPointsRender"], {'sizing_mode': 'scale_width'}]
     }
 
 figureLayoutDesc={


### PR DESCRIPTION
This PR adds a new input parameter for widgets and figures, name, which can be used as a key in layoutDesc (whether widgets or figures) See test_bokehDrawSA.py

Relates to #199

Also makes error handling for nonexistent columns less cryptic by sending CDS names to the client, and removes the boxess from heatmaps (copypasted from #209)