### PR TITLE
MakeJSCallback index slider, performance optimizations

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -75,9 +75,6 @@ export class CDSAlias extends ColumnarDataSource {
       let new_column = source.get_column(columnName)
       if(new_column == null){
         throw ReferenceError("Column not defined: "+ columnName + " in data source " + source.name)
-      }
-      else if (!Array.isArray(new_column)){
-        data[columnName] = Array.from(new_column)
       } else {
         data[columnName] = new_column
       }
@@ -114,9 +111,7 @@ export class CDSAlias extends ColumnarDataSource {
       if(new_column == null){
         throw ReferenceError("Column not defined: "+ column)
       }
-      else if (!Array.isArray(new_column)){
-        data[columnName] = Array.from(new_column)
-      } else {
+      else {
         data[columnName] = new_column
       }
     }

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -75,6 +75,9 @@ export class CDSAlias extends ColumnarDataSource {
       let new_column = source.get_column(columnName)
       if(new_column == null){
         throw ReferenceError("Column not defined: "+ columnName + " in data source " + source.name)
+      }
+      else if (!Array.isArray(new_column)){
+        data[columnName] = Array.from(new_column)
       } else {
         data[columnName] = new_column
       }
@@ -111,7 +114,9 @@ export class CDSAlias extends ColumnarDataSource {
       if(new_column == null){
         throw ReferenceError("Column not defined: "+ column)
       }
-      else {
+      else if (!Array.isArray(new_column)){
+        data[columnName] = Array.from(new_column)
+      } else {
         data[columnName] = new_column
       }
     }

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -144,6 +144,7 @@ export class CDSCompress extends ColumnDataSource {
         }
         if (dtype == "float32"){
           arrayOut = new Float32Array(arrayOut.buffer)
+          arrayOut = Array.from(arrayOut)
         }
         if (dtype == "float64"){
           arrayOut = new Float64Array(arrayOut.buffer)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -52,6 +52,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     this.view = null
     this._bin_indices = []
     this._do_cache_bins = true
+    this.invalidate_cached_bins()
     this.update_range()
   }
 
@@ -185,7 +186,6 @@ export class HistoNdCDS extends ColumnarDataSource {
           }
         }        
       }
-      this.invalidate_cached_bins()
       const dim = this.nbins.length
       this._nbins.length = dim
       this._transform_scale.length = dim

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -52,8 +52,6 @@ export class HistogramCDS extends ColumnarDataSource {
     super.connect_signals()
 
     this.connect(this.source.change, () => this.update_data())
-    this.connect(this.props.nbins.change, () => this.update_data())
-    this.connect(this.props.range.change, () => this.update_data())
   }
 
   update_data(indices: number[] | null = null): void {

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -52,6 +52,8 @@ export class HistogramCDS extends ColumnarDataSource {
     super.connect_signals()
 
     this.connect(this.source.change, () => this.update_data())
+    this.connect(this.props.nbins.change, () => this.update_data())
+    this.connect(this.props.range.change, () => this.update_data())
   }
 
   update_data(indices: number[] | null = null): void {

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -622,10 +622,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         if cdsType == "source":
             # HACK: Add "index" column for user convenience
             if "index" not in iSource["data"]:
-                try:
-                    iSource["data"]["index"] = iSource["data"].index
-                except:
-                    iSource["data"]["index"] = np.arange(len(list(iSource["data"].values())))
+                iSource["data"]["index"] = np.arange(len(list(iSource["data"].values)), dtype=np.int32)
             if "arrayCompression" in iSource and iSource["arrayCompression"] is not None:
                 iSource["cdsOrig"] = CDSCompress(name=name_orig)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -80,7 +80,7 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
         const widget = index.widget;
         const widgetType = index.type;
         const col = index.key && cdsOrig.get_column(index.key);
-        // TODO: Possibly use bisect, if this becomes bottleneck. Also add more widgets for index
+        // TODO: Add more widgets for index, not only range slider
         if(widgetType == "range"){
             const low = widget.value[0];
             const high = widget.value[1];
@@ -620,6 +620,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
 
         # Create cdsOrig
         if cdsType == "source":
+            # HACK: Add "index" column for user convenience
+            if "index" not in iSource["data"]:
+                try:
+                    iSource["data"]["index"] = iSource["data"].index
+                except:
+                    iSource["data"]["index"] = np.arange(len(list(iSource["data"].values())))
             if "arrayCompression" in iSource and iSource["arrayCompression"] is not None:
                 iSource["cdsOrig"] = CDSCompress(name=name_orig)
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -191,8 +191,8 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
         cdsSel.update()
         console.log(cdsSel._downsampled_indices.length);
         console.log(cdsSel.nPoints)
-        const t3 = performance.now();
-        console.log(`Updating cds took ${t3 - t2} milliseconds.`);
+        const t4 = performance.now();
+        console.log(`Updating cds took ${t4 - t3} milliseconds.`);
     }
     if(options.cdsHistoSummary !== null){
         options.cdsHistoSummary.update();

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogramWeight.py
@@ -35,8 +35,9 @@ widgetParams = [
     ['range', ['B']],
     ['range', ['C']],
     ['multiSelect', ['D']],
+    ['range', ['index'], {"index": True}],
 ]
-widgetLayoutDesc = [[0, 1], [2, 3], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc = [[0, 1], [2, 3, 4], {'sizing_mode': 'scale_width'}]
 
 figureLayoutDesc = [
     [0, 1, {'y_visible': 1, 'x_visible': 1, 'plot_height': 150}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -75,7 +75,7 @@ tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)
 
 widgetParams=[
     ['range', ['A']],
-    ['range', ['B', 0, 1, 0.1, 0, 1]],
+    ['range', ['B', 0, 1, 0.1, 0, 1], {"index": True}],
 
     ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],


### PR DESCRIPTION
This PR:

- Adds an "index" parameter for range sliders. Points outside the range are not considered for the selection. The column for it must be sorted, but it improves performance. Possible smarter indexing in future PR
- Adds an "index" column to data sources if not specified - not sure if it should be kept, ambiguous requirements
- Optimizes auto ranges in histograms
- Removes bin caching in ND histograms with auto ranges - in some use cases leads to improved performance
- Changes Float32Arrays in CDSCompress to normal arrays - seems to improve the performance