### PR TITLE
MultiSelect optimization/bugfix

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -174,7 +174,25 @@ export class CDSAlias extends ColumnarDataSource {
   }
 
   invalidate_column(key: string, emit_change=true){
+    if(!this.cached_columns.has(key)) return
     this.cached_columns.delete(key)
+    // A bruteforce solution should work, there shouldn't be that many columns that it's problematic
+    const candidate_columns = Object.keys(this.mapping)
+    for(const new_key of candidate_columns){
+      const column = this.mapping[new_key]
+      let should_invalidate = false
+      if(column.hasOwnProperty("fields")){
+        for(let i=0; i<column.fields.length; i++){
+          if(key == column.fields[i]){
+            should_invalidate = true
+            break
+          }
+        }
+      }
+      if(should_invalidate){
+        this.invalidate_column(new_key, false)
+      }
+    }
     if(emit_change){
       this.change.emit()
     }

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -73,6 +73,8 @@ export class CDSAlias extends ColumnarDataSource {
   compute_function(key: string){
     const {source, mapping, data, cached_columns} = this
     const column = mapping[key]
+    const len = this.get_length()
+    if(len == null) return
     if(column == null){
       let new_column = source.get_column(key)
       if(new_column == null){
@@ -108,7 +110,7 @@ export class CDSAlias extends ColumnarDataSource {
             new_column.length = source.get_length()
             const nvars = fields.length
             let row = new Array(nvars)
-            for (let i = 0; i < fields[0].length; i++) {
+            for (let i = 0; i < len; i++) {
               for(let j=0; j<nvars; j++){
                 row[j] = fields[j][i]
               }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1184,7 +1184,11 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                                     cdsHistoSummary=cdsHistoSummary, profileList=profileList, aliasDict=list(aliasDict.values()), index=index)
         for iWidget in widgetList:
             if "filter" in iWidget:
-                iWidget["filter"].source = cdsFull
+                field = iWidget["filter"].field
+                if memoized_columns[iCds][field]["type"] == "alias":
+                    iWidget["filter"].source = cdsFull
+                else:
+                    iWidget["filter"].source = cdsOrig
                 iWidget["filter"].js_on_change("change", callback)
             else:
                 iWidget["widget"].js_on_change("value", callback)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1178,6 +1178,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         index = None
         if "index" in widgets:
             index = widgets["index"]
+        cdsOrig = cdsDict[iCds]["cdsOrig"]
         cdsFull = cdsDict[iCds]["cdsFull"]
         source = cdsDict[iCds]["cds"]
         callback = makeJScallback(widgetList, cdsFull, source, histogramList=histoList,


### PR DESCRIPTION
This PR:
- fixes a bug where selections for multi-selects are invalidated when an unrelated derived column change - bokehTools.py - the bug was introduced in #212
- Adds a simple dependency tree for derived columns on the client, optimizing recomputing them as a side effect by saving some garbage collection time - CDSAlias.ts - this should also make derived columns update properly when dependencies are changed, preparation for making the text input widgets as discussed in ATO-595

* Fix problem with suboptimal performance of parametric aliases - reported in ALICE fastCombinator tracking use case 
  * https://alice.its.cern.ch/jira/browse/ATO-595
  * avoid multiple updates  (1 update instead of the ~ 10 updates - number of multi-select widgets in dashboard)