### PR TITLE
Custom JS function text input

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -568,9 +568,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             else:
                 if i["func"] in paramDict:
                     transform = CustomJSNAryFunction(parameters=customJsArgList, fields=i["variables"], func=paramDict[i["func"]]["value"])
-                    paramDict[i["func"]].append(["value", CustomJS(args={"mapper":transform}, code="""
+                    paramDict[i["func"]]["subscribed_events"].append(["value", CustomJS(args={"mapper":transform}, code="""
             mapper.func = this.value
-            mapper.update_args()
+            mapper.update_func()
+            mapper.change.emit()
                     """)])
                 else:
                     transform = CustomJSNAryFunction(parameters=customJsArgList, fields=i["variables"], func=i["func"])
@@ -868,6 +869,18 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if cds_used not in widgetDict:
                 widgetDict[cds_used] = {"widgetList":[]}
             widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None})
+            continue
+        if variables[0] == "text":
+            optionWidget = {"title": variables[1][0]}
+            if len(variables) > 2:
+                optionWidget.update(variables[-1])
+            value = paramDict[variables[1][0]]["value"]
+            localWidget = TextAreaInput(value=value, **optionWidget)
+            plotArray.append(localWidget)
+            if "name" in optionLocal:
+                plotDict[optionLocal["name"]] = localWidget
+            widgetArray.append(localWidget)
+            widgetParams.append(variables)
             continue
 
         optionLocal = optionGroup.copy()

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -860,12 +860,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         if variables[0] == "textQuery":
             optionWidget = {}
             if len(variables) >= 2:
-                optionWidget = variables[-1].copy()
+                optionWidget.update(variables[-1])
             cds_used = None
             localWidget = TextAreaInput(**optionWidget)
             plotArray.append(localWidget)
-            if "name" in optionLocal:
-                plotDict[optionLocal["name"]] = localWidget
+            if "name" in optionWidget:
+                plotDict[optionWidget["name"]] = localWidget
             if cds_used not in widgetDict:
                 widgetDict[cds_used] = {"widgetList":[]}
             widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None})
@@ -877,8 +877,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             value = paramDict[variables[1][0]]["value"]
             localWidget = TextAreaInput(value=value, **optionWidget)
             plotArray.append(localWidget)
-            if "name" in optionLocal:
-                plotDict[optionLocal["name"]] = localWidget
+            if "name" in optionWidget:
+                plotDict[optionWidget["name"]] = localWidget
             widgetArray.append(localWidget)
             widgetParams.append(variables)
             continue

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -108,13 +108,13 @@ widgetParams=[
     ['select',["legendFontSize"]],
     ['slider',["C_cut"]],
     ['slider',["paramX"]],
-    ['text', ["CustomFunc"]]
+    ['text', ["CustomFunc"], {"name": "CustomFunc"}]
 ]
 
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], {'sizing_mode': 'scale_width'}],
     "Graphics": [[5, 6], {'sizing_mode': 'scale_width'}],
-    "CustomJS functions": [[7, 8],[9]]
+    "CustomJS functions": [[7, 8],["CustomFunc"]]
     }
 
 figureLayoutDesc=[
@@ -187,3 +187,5 @@ def test_makeColumns():
     print(ctx_updated)
     print(memoized_columns)
     print(sources)
+
+test_customJsFunctionBokehDrawArray_v()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -22,7 +22,8 @@ parameterArray = [
     {"name": "size", "value":7, "range":[0, 30]},
     {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
     {"name": "paramX", "value":10, "range": [-20, 20]},
-    {"name": "C_cut", "value": 1, "range": [0, 1]}
+    {"name": "C_cut", "value": 1, "range": [0, 1]},
+    {"name": "CustomFunc", "value":"return 0;"}
 ]
 
 # This interface with two arrays is only for the case when functions are reused with different columns as target
@@ -59,11 +60,16 @@ aliasArray = [
         "variables": ["entries", "entries_C_cut"],
         "func": "return entries_C_cut / entries",
         "context": "histoAC"
+    },
+    {
+        "name": "custom_column",
+        "variables": ["A", "B", "C", "A_mul_paramX_plus_B"],
+        "func": "CustomFunc"
     }
 ]
 
 figureArray = [
-    [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B'], {"size":"size"}],
+    [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B', "custom_column"], {"size":"size"}],
     [['histoA.bin_center'], ['efficiency_A'], {"context":"histoA", "size":"size"}],
     [['histoA.bin_center'], ['histoA.entries', 'histoA.entries_C_cut'], {"context":"histoA", "size":"size"}],
     [['histoAC.bin_center_0'], ['efficiency_AC'], {"context":"histoAC", "size":"size", "colorZvar": "histoAC.bin_center_1"}],
@@ -102,12 +108,13 @@ widgetParams=[
     ['select',["legendFontSize"]],
     ['slider',["C_cut"]],
     ['slider',["paramX"]],
+    ['text', ["CustomFunc"]]
 ]
 
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], {'sizing_mode': 'scale_width'}],
     "Graphics": [[5, 6], {'sizing_mode': 'scale_width'}],
-    "CustomJS functions": [[7, 8]]
+    "CustomJS functions": [[7, 8],[9]]
     }
 
 figureLayoutDesc=[
@@ -180,6 +187,3 @@ def test_makeColumns():
     print(ctx_updated)
     print(memoized_columns)
     print(sources)
-
-test_makeColumns()
-#test_customJsFunctionBokehDrawArray_v()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -23,7 +23,7 @@ parameterArray = [
     {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
     {"name": "paramX", "value":10, "range": [-20, 20]},
     {"name": "C_cut", "value": 1, "range": [0, 1]},
-    {"name": "CustomFunc", "value":"return 0;"}
+    {"name": "CustomFunc", "value":"return Math.sin(A_mul_paramX_plus_B)"}
 ]
 
 # This interface with two arrays is only for the case when functions are reused with different columns as target

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -187,5 +187,3 @@ def test_makeColumns():
     print(ctx_updated)
     print(memoized_columns)
     print(sources)
-
-test_customJsFunctionBokehDrawArray_v()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -61,7 +61,7 @@ parameterArray = [
 figureArray = [
 #   ['A'], ['C-A'], {"color": "red", "size": 7, "colorZvar":"C", "filter": "A<0.5"}],
     [['A'], ['A*A-C*C'], {"color": "red", "size": 2, "colorZvar": "A", "varZ": "C", "errY": "errY", "errX":"0.01"}],
-    [['X'], ['C+A', 'C-A', 'A/A']],
+    [['X'], ['C+A', 'C-A', 'A/A'], {"name": "fig1"}],
     [['B'], ['C+B', 'C-B'], { "colorZvar": "colorZ", "errY": "errY", "rescaleColorMapper": True}],
     [['D'], ['(A+B+C)*DD'], {"colorZvar": "colorZ", "size": 10, "errY": "errY"} ],
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
@@ -85,7 +85,7 @@ widgetParams=[
     ['multiSelectBitmask', ["maskAC"], {"mapping": {"A": 2, "C": 1}, "how":"all", "title": "maskAC(all)"}],
     ['select',["CC", 0, 1, 2, 3], {"default": 1}],
     ['multiSelect',["BoolB"]],
-    ['textQuery', {"title": "selection"}],
+    ['textQuery', {"title": "selection", "name":"selectionText"}],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted
     ['select',["colorZ"], {"name": "colorZ"}],
     ['select',["X"], {"name": "X"}],
@@ -96,13 +96,13 @@ widgetParams=[
 ]
 
 widgetLayoutDesc={
-    "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8, 9], {'sizing_mode': 'scale_width'}],
+    "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8, "selectionText"], {'sizing_mode': 'scale_width'}],
     "Graphics": [["colorZ", "X", "markerSize"], ["legendFontSize", "legendVisible", "nPointsRender"], {'sizing_mode': 'scale_width'}]
     }
 
 figureLayoutDesc={
     "A": [
-        [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [0, "fig1", 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
         ],
     "B": [


### PR DESCRIPTION
This PR:
-Adds a test for custom JS function text input - test_Alias.py
-Fixes bugs preventing it from working - seems that for some reason, it was already mostly implemented, and the only changes needed were fixing a broken 2-line JS callback, and creating the text input widget itself.
Fixes #229 

How to use:
In widget array, create a "text" widget, where the relevant argument is parameter name
```
aliasArray=[
    {
        "name": "custom_column",
        "variables": ["A", "B", "C", "A_mul_paramX_plus_B"],
        "func": "CustomFunc"
    }
]
parameterArray=[
    {"name": "CustomFunc", "value":"return Math.sin(A_mul_paramX_plus_B)"}
]
widgetParams=[
   ...,
    ['text', ["CustomFunc"]],
   ....
]
```

Screenshot of result:
![Capture](https://user-images.githubusercontent.com/3155456/181014753-9a69ee58-c90b-4397-853b-32874e78e574.PNG)

