### PR TITLE
Histogram edge case with auto ranges fix

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -253,7 +253,7 @@ export class HistoNdCDS extends ColumnarDataSource {
 
         // Make the max value inclusive
         if(val === this._range_max[i]){
-          bin += this._nbins[i] * this._strides[i] - 1
+          bin += (this._nbins[i] - 1) * this._strides[i]
         } else {
           bin += ((val * this._transform_scale[i] - this._transform_origin[i]) | 0) * this._strides[i]
         }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -332,6 +332,10 @@ export class HistoNdCDS extends ColumnarDataSource {
       range_min = Math.min(range_min, column[x])
       range_max = Math.max(range_max, column[x])
     }
+    if(range_min == range_max){
+      range_min -= .5
+      range_max += .5
+    }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    
     this._do_cache_bins = false
@@ -346,6 +350,10 @@ export class HistoNdCDS extends ColumnarDataSource {
       const y = view[x]
       range_min = Math.min(range_min, column[y])
       range_max = Math.max(range_max, column[y])
+    }
+    if(range_min == range_max){
+      range_min -= .5
+      range_max += .5
     }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -253,7 +253,7 @@ export class HistoNdCDS extends ColumnarDataSource {
 
         // Make the max value inclusive
         if(val === this._range_max[i]){
-          bin += this._nbins[i] * this._strides[i]
+          bin += this._nbins[i] * this._strides[i] - 1
         } else {
           bin += ((val * this._transform_scale[i] - this._transform_origin[i]) | 0) * this._strides[i]
         }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -85,6 +85,10 @@ export class HistogramCDS extends ColumnarDataSource {
             range_min = Math.min(range_min, sample_arr[x])
             range_max = Math.max(range_max, sample_arr[x])
           }
+          if(range_min == range_max){
+            range_min -= 1
+            range_max += 1
+          }
           this._range_min = range_min
           this._range_max = range_max
         } else {
@@ -105,6 +109,10 @@ export class HistogramCDS extends ColumnarDataSource {
             const y = view[x]
             range_min = Math.min(range_min, sample_arr[y])
             range_max = Math.max(range_max, sample_arr[y])
+          }
+          if(range_min == range_max){
+            range_min -= 1
+            range_max += 1
           }
           this._range_min = range_min
           this._range_max = range_max


### PR DESCRIPTION
This PR fixes the behavior of N-dimensional histograms in some edge cases by:
- Making the top edge of the top bin inclusive correctly, before it was off by one
- Adding a workaround to auto ranges when min == max by decrementing min and incrementing max - to prevent division by zero