### PR TITLE
Histogram ranges / number of bins widgets

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -71,10 +71,13 @@ export class DownsamplerCDS extends ColumnarDataSource {
   update(){
     const {source, nPoints, selected, booleans, _indices} = this
     const l = source.length
+    if(this._indices.length < l){
+      this.shuffle_indices()
+    }
     // Maybe add different downsampling strategies for small or large nPoints?
     // This is only efficient if the downsampling isn't too aggressive.
     this._downsampled_indices = []
-    for(let i=0; i<l && this._downsampled_indices.length < nPoints; i++){
+    for(let i=0; i < this._indices.length && this._downsampled_indices.length < nPoints; i++){
       if (_indices[i]<l && (booleans == null || booleans[_indices[i]])){
         this._downsampled_indices.push(_indices[i])
       }

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -161,6 +161,9 @@ export class DownsamplerCDS extends ColumnarDataSource {
   }
 
   get_length(){
+    if(this.watched && this._needs_update){
+      this.update()
+    }
     return this._downsampled_indices.length
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -333,8 +333,8 @@ export class HistoNdCDS extends ColumnarDataSource {
       range_max = Math.max(range_max, column[x])
     }
     if(range_min == range_max){
-      range_min -= .5
-      range_max += .5
+      range_min -= 1
+      range_max += 1
     }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    
@@ -352,8 +352,8 @@ export class HistoNdCDS extends ColumnarDataSource {
       range_max = Math.max(range_max, column[y])
     }
     if(range_min == range_max){
-      range_min -= .5
-      range_max += .5
+      range_min -= 1
+      range_max += 1
     }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    
@@ -364,6 +364,17 @@ export class HistoNdCDS extends ColumnarDataSource {
     this._stale_range = true
     this.data = {}
     this.change.emit()
+  }
+
+  update_nbins(){
+    const dim = this.nbins.length
+    this._nbins.length = dim
+    this._strides.length = dim+1
+    this._strides[0] = 1
+    for(let i=0; i<dim; i++){
+      this._nbins[i] = this.nbins[i]
+      this._strides[i+1] = this._strides[i]*this._nbins[i]
+    }    
   }
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -28,6 +28,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     this._transform_origin = []
     this._transform_scale = []
     this._strides = []
+    this._nbins = []
   }
 
   static __name__ = "HistoNdCDS"
@@ -53,7 +54,8 @@ export class HistoNdCDS extends ColumnarDataSource {
     this._bin_indices = []
     this._do_cache_bins = true
     this.invalidate_cached_bins()
-    this.update_range()
+    this.update_nbins()
+    this._stale_range = true
   }
 
   connect_signals(): void {
@@ -374,7 +376,8 @@ export class HistoNdCDS extends ColumnarDataSource {
     for(let i=0; i<dim; i++){
       this._nbins[i] = this.nbins[i]
       this._strides[i+1] = this._strides[i]*this._nbins[i]
-    }    
+    }
+    this.dim = dim
   }
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -101,7 +101,9 @@ export class HistoNdProfile extends ColumnarDataSource {
         const edges_left = this.source.get_column("bin_bottom_"+this.axis_idx) as number[]
         const edges_right = this.source.get_column("bin_top_"+this.axis_idx) as number[]
 
-        for(let x = 0; x < this.source.length; x += stride_high){
+        const nbins_total = this.source.length
+
+        for(let x = 0; x < nbins_total; x += stride_high){
           for(let z = 0; z < stride_low; z ++){
       //      console.log(x)
       //      console.log(z)
@@ -240,10 +242,7 @@ export class HistoNdProfile extends ColumnarDataSource {
   }
 
   get_length(){
-    if(this._stale){
-      this.update()
-    }
-    return this.data["entries"].length
+    return this.source.get_length() / this.source.nbins[this.axis_idx]
   }
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -686,7 +686,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 iSource["tooltips"] = defaultHisto2DTooltips
             nbins = [10]*len(iSource["variables"])
             if "nbins" in iSource:
-                nbins = iSource["nbins"]
+                nbins = iSource["nbins"].copy()
             for binsIdx, iBins in enumerate(nbins):
                 if isinstance(iBins, str) and iBins in paramDict:
                     paramDict[iBins]["subscribed_events"].append(["value", CustomJS(args={"histogram":iSource["cdsOrig"], "i": binsIdx}, code="""
@@ -698,7 +698,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     nbins[binsIdx] = paramDict[iBins]["value"]
             histoRange = None
             if "range" in iSource:
-                histoRange = iSource["range"]
+                histoRange = iSource["range"].copy()
             if histoRange is not None:
                 for rangeIdx, iRange in enumerate(histoRange):
                     if isinstance(iRange, str) and iRange in paramDict:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -933,8 +933,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 variablesLocal[axis_index] = optionLocal[axis_name]
             if variablesLocal[axis_index] is not None and not isinstance(variablesLocal[axis_index], list):
                 variablesLocal[axis_index] = [variablesLocal[axis_index]]
-        lengthX = len(variables[0])
-        lengthY = len(variables[1])
         length = max(j is not None and len(j) for j in variablesLocal)
         cds_names = [None]*length
         if "source" in optionLocal:
@@ -977,7 +975,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         lengthY = len(variables[1])
         length = max(len(variables[0]), len(variables[1]))
         color_bar = None
-        mapperC = None
         cmap_cds_name = None
 
         hover_tool_renderers = {}
@@ -1500,7 +1497,7 @@ def connectWidgetCallbacks(widgetParams: list, widgetArray: list, paramDict: dic
         params = iDesc[1]
         callback = None
         if len(iDesc) == 3:
-            optionLocal = iDesc[2]
+            optionLocal = iDesc[2].copy()
         if "callback" not in optionLocal:
             if params[0] in paramDict:
                 optionLocal["callback"] = "parameter"

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -750,7 +750,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
 
         name_full = "cdsFull"
         if cds_name is not None:
-            name_orig = cds_name+"_orig"
+            name_full = cds_name+"_full"
         # Add middleware for aliases
         iSource["cdsFull"] = CDSAlias(source=iSource["cdsOrig"], mapping={}, name=name_full)
 
@@ -1187,8 +1187,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         elif cdsValue["type"] in ["histogram", "histo2d", "histoNd"]:
             cdsOrig = cdsValue["cdsOrig"]
             cdsOrig.source = cdsDict[cdsValue["source"]]["cdsFull"]
-            if cdsValue["source"] is None:
-                histoList.append(cdsOrig)
             if "histograms" in cdsValue:
                 for key, value in memoized_columns[cdsKey].items():
                     if key in cdsValue["histograms"]:
@@ -1227,6 +1225,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         cdsOrig = cdsDict[iCds]["cdsOrig"]
         cdsFull = cdsDict[iCds]["cdsFull"]
         source = cdsDict[iCds]["cds"]
+        histoList = []
+        for cdsKey, cdsValue in cdsDict.items():
+            if cdsKey not in memoized_columns:
+                continue
+            if cdsValue["type"] in ["histogram", "histo2d", "histoNd"] and cdsValue["source"] == iCds:
+                histoList.append(cdsValue["cdsOrig"])
         callback = makeJScallback(widgetList, cdsFull, source, histogramList=histoList,
                                     cdsHistoSummary=cdsHistoSummary, profileList=profileList, aliasDict=list(aliasDict.values()), index=index)
         for iWidget in widgetList:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1009,7 +1009,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     if cdsDict[cds_name]["type"] == "projection" and not rescaleColorMapper and varColor["name"].split('_')[0] == 'bin':
                         cdsDict[cds_name]['cds'].js_on_change('change', CustomJS(code="""
                         const col = this.get_column(field)
-                        const isOK = this.data.isOK
+                        const isOK = this.get_column("isOK")
                         const low = col.map((x,i) => isOK[i] ? col[i] : Infinity).reduce((acc, cur)=>Math.min(acc,cur), Infinity);
                         const high = col.map((x,i) => isOK[i] ? col[i] : -Infinity).reduce((acc, cur)=>Math.max(acc,cur), -Infinity);
                         cmap.high = high;

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -648,9 +648,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             else:
                 iSource["cdsOrig"] = ColumnDataSource(name=name_orig)
         elif cdsType == "histogram":
-            nbins = 10
-            if "nbins" in iSource:
-                nbins = iSource["nbins"]
             weights = None
             if "weights" in iSource:
                 weights = iSource["weights"]
@@ -659,9 +656,22 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 histoRange = iSource["range"]
             if "source" not in iSource:
                 iSource["source"] = None
-            iSource["cdsOrig"] = HistogramCDS(nbins=nbins, sample=iSource["variables"][0], weights=weights, range=histoRange, name=name_orig)
+            iSource["cdsOrig"] = HistogramCDS(sample=iSource["variables"][0], weights=weights, name=name_orig)
             if "tooltips" not in iSource:
                 iSource["tooltips"] = defaultHistoTooltips
+            nbins = 10
+            if "nbins" in iSource:
+                nbins = iSource["nbins"]
+            if nbins in paramDict:
+                paramDict[nbins]["subscribed_events"].append(["value", iSource["cdsOrig"], "nbins"])
+                nbins = paramDict[nbins]["value"]
+            histoRange = None
+            if "range" in iSource:
+                histoRange = iSource["range"]
+            if isinstance(histoRange, str) and histoRange in paramDict:
+                paramDict[histoRange]["subscribed_events"].append(["value", iSource["cdsOrig"], "range"])
+                histoRange = paramDict[histoRange]["value"]
+            iSource["cdsOrig"].update(nbins=nbins, range=histoRange)
         elif cdsType in ["histo2d", "histoNd"]:
             nbins = [10]*len(iSource["variables"])
             if "nbins" in iSource:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1010,8 +1010,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                             colorMapperDict[varColor["name"]] = mapperC
                     # HACK for projections - should probably just remove the rows as there's no issue with joins at all
                     if cdsDict[cds_name]["type"] == "projection" and not rescaleColorMapper and varColor["name"].split('_')[0] == 'bin':
-                        cdsDict[cds_name]['cdsOrig'].js_on_change('change', CustomJS(code="""
-                        const col = this.data[field]
+                        cdsDict[cds_name]['cds'].js_on_change('change', CustomJS(code="""
+                        const col = this.get_column(field)
                         const isOK = this.data.isOK
                         const low = col.map((x,i) => isOK[i] ? col[i] : Infinity).reduce((acc, cur)=>Math.min(acc,cur), Infinity);
                         const high = col.map((x,i) => isOK[i] ? col[i] : -Infinity).reduce((acc, cur)=>Math.max(acc,cur), -Infinity);

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -687,9 +687,15 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             nbins = [10]*len(iSource["variables"])
             if "nbins" in iSource:
                 nbins = iSource["nbins"]
-    #        if nbins in paramDict:
-    #            paramDict[nbins]["subscribed_events"].append(["value", iSource["cdsOrig"], "nbins"])
-    #            nbins = paramDict[nbins]["value"]
+            for binsIdx, iBins in enumerate(nbins):
+                if isinstance(iBins, str) and iBins in paramDict:
+                    paramDict[iBins]["subscribed_events"].append(["value", CustomJS(args={"histogram":iSource["cdsOrig"], "i": binsIdx}, code="""
+                        histogram.nbins[i] = this.value | 0;
+                        histogram.update_nbins();
+                        histogram.invalidate_cached_bins();
+                        histogram.change_selection();
+                    """)])
+                    nbins[binsIdx] = paramDict[iBins]["value"]
             histoRange = None
             if "range" in iSource:
                 histoRange = iSource["range"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -663,7 +663,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if "nbins" in iSource:
                 nbins = iSource["nbins"]
             if nbins in paramDict:
-                paramDict[nbins]["subscribed_events"].append(["value", iSource["cdsOrig"], "nbins"])
+                paramDict[nbins]["subscribed_events"].append(["value", CustomJS(args={"histogram":iSource["cdsOrig"]}, code="""
+                            histogram.nbins = this.value | 0;
+                            histogram.change_selection();
+                        """)])
                 nbins = paramDict[nbins]["value"]
             histoRange = None
             if "range" in iSource:
@@ -839,7 +842,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                         fakeDf = {varName: dfQuery[varName]}
                     elif column[0]["type"] == "server_derived_column":
                         fakeDf = {varName: column[0]["value"]}
-                    sources.update(used_names_local)
+                    if variables[0] != 'multiSelect':
+                        sources.update(used_names_local)
             if variables[0] == 'slider':
                 localWidget = makeBokehSliderWidget(fakeDf, False, variables[1], paramDict, **optionWidget)
             if variables[0] == 'range':

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -150,7 +150,7 @@ def testBokehClientHistogramRowwiseTable():
 def testBokehClientHistogram3d():
     output_file("test_BokehClientHistogram3d.html")
     histoArray = [
-        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]]},
+        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, "nBinsB", 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]]},
     ]
     figureArray = [
         [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
@@ -163,14 +163,14 @@ def testBokehClientHistogram3d():
         [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
-    
+    widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
 def testBokehClientHistogram3d_colormap():
     output_file("test_BokehClientHistogram_colormap.html")
     histoArray = [
-        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
+        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, "nBinsB", 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
         "range": [[0,1],[0,1],[0,1]]},
     ]
     figureArray = [
@@ -185,6 +185,7 @@ def testBokehClientHistogram3d_colormap():
         [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
+    widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
@@ -192,7 +193,7 @@ def testBokehClientHistogram3d_colormap():
 def testBokehClientHistogram3d_colormap_noscale():
     output_file("test_BokehClientHistogram_colormap_noscale.html")
     histoArray = [
-        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
+        {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, "nBinsB", 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]],
         "range": [[0,1],[0,1],[0,1]]}
     ]
     figureArray = [
@@ -207,7 +208,7 @@ def testBokehClientHistogram3d_colormap_noscale():
         [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
-    
+    widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray)
 
@@ -228,8 +229,8 @@ def testJoin():
         }
     ]
     histoArray = [
-        {"name": "histoAB", "variables": ["A", "B"], "nbins": [10, 10], "axis": [0]},
-        {"name": "histoB", "variables": ["B"], "nbins": 10,
+        {"name": "histoAB", "variables": ["A", "B"], "nbins": [10, "nBinsB"], "range": ["rangeA", None], "axis": [0]},
+        {"name": "histoB", "variables": ["B"], "nbins": "nBinsB",
             "histograms": {
                 "sum_A": {"weights": "A"}
             }

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -148,7 +148,7 @@ def testBokehClientHistogramRowwiseTable():
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 
 def testBokehClientHistogram3d():
-    output_file("test_BokehClientHistogram.html")
+    output_file("test_BokehClientHistogram3d.html")
     histoArray = [
         {"name": "histoABC", "variables": ["(A+C)/2", "B", "C"], "nbins": [8, 10, 12], "weights": "D", "axis": [0], "sum_range": [[.25, .75]]},
     ]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -56,7 +56,7 @@ histoArray = [
     {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
     {"name": "histoB", "variables": ["B"], "nbins":20, "range": [0, 1]},
     {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, 5, 10], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
-    {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, 20], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
+    {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, 20], "range": ["histoRangeA", None], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
 ]
 
 def testBokehClientHistogram():

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -30,7 +30,8 @@ figureLayout: str = '((0,1,2, plot_height=300),commonX=1,plot_height=300,plot_wi
 tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)")]
 
 parameterArray=[
-    {'name':"size", "value":7, "range": [0, 20]}
+    {'name':"size", "value":7, "range": [0, 20]},
+    {'name':"histoRangeA", "value": [0, 1], "range": [0, 1]}
 ]
 
 widgetParams=[
@@ -40,10 +41,11 @@ widgetParams=[
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['multiSelect', ["DDC"]],
     ['slider',["size"]],
+    ['range', ['histoRangeA']]
   #  ['select',["CC", 0, 1, 2, 3]],
   #  ['multiSelect',["BoolB"]],
 ]
-widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], [6], {'sizing_mode': 'scale_width'}]
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -51,7 +53,7 @@ figureLayoutDesc=[
 ]
 
 histoArray = [
-    {"name": "histoA", "variables": ["A"], "nbins":20, "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
+    {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
     {"name": "histoB", "variables": ["B"], "nbins":20, "range": [0, 1]},
     {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, 5, 10], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
     {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, 20], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
@@ -249,3 +251,6 @@ def testJoin():
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, sourceArray=sourceArray, aliasArray=aliasArray)
+
+
+testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -31,7 +31,8 @@ tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)
 
 parameterArray=[
     {'name':"size", "value":7, "range": [0, 20]},
-    {'name':"histoRangeA", "value": [0, 1], "range": [0, 1]}
+    {'name':"histoRangeA", "value": [0, 1], "range": [0, 1]},
+    {'name':"nBinsB", "value": 20, "options":[5, 10, 20, 40]}
 ]
 
 widgetParams=[
@@ -41,11 +42,12 @@ widgetParams=[
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['multiSelect', ["DDC"]],
     ['slider',["size"]],
-    ['range', ['histoRangeA']]
+    ['range', ['histoRangeA']],
+    ['select', ['nBinsB']]
   #  ['select',["CC", 0, 1, 2, 3]],
   #  ['multiSelect',["BoolB"]],
 ]
-widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], [6], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], [6, 7], {'sizing_mode': 'scale_width'}]
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -54,7 +56,7 @@ figureLayoutDesc=[
 
 histoArray = [
     {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
-    {"name": "histoB", "variables": ["B"], "nbins":20, "range": [0, 1]},
+    {"name": "histoB", "variables": ["B"], "nbins":"nBinsB", "range": [0, 1]},
     {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, 5, 10], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
     {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, 20], "range": ["histoRangeA", None], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
 ]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -57,7 +57,7 @@ figureLayoutDesc=[
 histoArray = [
     {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
     {"name": "histoB", "variables": ["B"], "nbins":"nBinsB", "range": [0, 1]},
-    {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, 5, 10], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
+    {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, "nBinsB", 10], "range": ["histoRangeA", None, None], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
     {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, "nBinsB"], "range": ["histoRangeA", None], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
 ]
 
@@ -254,3 +254,4 @@ def testJoin():
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, sourceArray=sourceArray, aliasArray=aliasArray)
+

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -58,7 +58,7 @@ histoArray = [
     {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
     {"name": "histoB", "variables": ["B"], "nbins":"nBinsB", "range": [0, 1]},
     {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, 5, 10], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
-    {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, 20], "range": ["histoRangeA", None], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
+    {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, "nBinsB"], "range": ["histoRangeA", None], "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
 ]
 
 def testBokehClientHistogram():
@@ -253,6 +253,3 @@ def testJoin():
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, sourceArray=sourceArray, aliasArray=aliasArray)
-
-
-testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -229,7 +229,7 @@ def testJoin():
         }
     ]
     histoArray = [
-        {"name": "histoAB", "variables": ["A", "B"], "nbins": [10, "nBinsB"], "range": ["rangeA", None], "axis": [0]},
+        {"name": "histoAB", "variables": ["A", "B"], "nbins": [10, "nBinsB"], "range": ["histoRangeA", None], "axis": [0]},
         {"name": "histoB", "variables": ["B"], "nbins": "nBinsB",
             "histograms": {
                 "sum_A": {"weights": "A"}

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -159,8 +159,8 @@ def testBokehClientHistogram3d():
         [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}]
     ]
     figureLayoutDesc=[
-        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
-        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]
@@ -181,8 +181,8 @@ def testBokehClientHistogram3d_colormap():
         {"size": "size", "rescaleColorMapper": True}
     ]
     figureLayoutDesc=[
-        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
-        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]
@@ -204,8 +204,8 @@ def testBokehClientHistogram3d_colormap_noscale():
         {"size": "size"}
     ]
     figureLayoutDesc=[
-        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
-        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
+        [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+        [2, 3, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
         {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2}
     ]
     widgetLayoutDesc = [[0, 1, 2], [3, 4], [5], [7], {'sizing_mode': 'scale_width'}]


### PR DESCRIPTION
This PR:
- Allows modifying histogram ranges and number of bins on the client using parameterArray
- Fixes a bug with ND histogram where it wasn't updating the length correctly (as the length was never updated in any use case, the bug wasn't really a bug before the nbins parameter was added)
- Fixes a bug in the downsampler with changing input sizes (before this change, it was an edge case, this change made it visible)
- Slightly optimizes the dependency tree by not adding the pre-transformation multiSelect columns
- in test_bokehClientHistogram.py fixes the output file name for test_bokehClientHistogram3d
- Fixes a bug caused in #172 causing widgetArray to sometimes get modified in place
   - was there   since Nov 20, 2021, but this fragment of code not used until text input for selection


Relates to #218
