### PR TITLE
Toggleable widgets

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.py
@@ -1,0 +1,10 @@
+from bokeh.model import Model
+from bokeh.core.properties import Instance, String, Tuple, Float
+from bokeh.models.sources import ColumnarDataSource
+
+class RangeFilter(Model):
+    __implementation__ = "RangeFilter.ts"
+
+    source = Instance(ColumnarDataSource, help="Column data source to select from")
+    field = String(help="The field to check") # May change it to a formula instead
+    range = Tuple(Float(), Float(), help="The range to use - default options are [-Infinity, Infinity]")

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -1,0 +1,89 @@
+import {ColumnarDataSource} from "models/sources/columnar_data_source"
+import {Model} from "model"
+import * as p from "core/properties"
+
+export namespace RangeFilter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    source: p.Property<ColumnarDataSource>
+    field: p.Property<string>
+    range: p.Property<number[]>
+  }
+}
+
+export interface RangeFilter extends RangeFilter.Attrs {}
+
+export class RangeFilter extends Model {
+  properties: RangeFilter.Props
+
+  constructor(attrs?: Partial<RangeFilter.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "RangeFilter"
+
+  static init_RangeFilter() {
+    this.define<RangeFilter.Props>(({Ref, Number, String, Array})=>({
+      source:  [Ref(ColumnarDataSource)],
+      field: [String],
+      range: [Array(Number)]
+    }))
+  }
+
+  private cached_vector: boolean[]
+  private dirty_source: boolean
+  private dirty_widget: boolean
+
+  public index_low: number
+  public index_high: number
+
+  initialize(){
+    super.initialize()
+    this.dirty_source = true
+    this.dirty_widget = true
+    this.index_low = 0
+    this.index_high = -1
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+
+    this.connect(this.properties.range.change, this.mark_dirty_widget)
+    this.connect(this.source.change, this.mark_dirty_source)
+  }
+
+  mark_dirty_widget(){
+    this.dirty_widget = true
+    this.change.emit()
+  }
+
+  mark_dirty_source(){
+    this.dirty_source = true
+    this.change.emit()
+  }
+
+  public v_compute(): boolean[]{
+    const {dirty_source, dirty_widget, cached_vector, source, field} = this
+    if (!dirty_source && !dirty_widget){
+        return cached_vector
+    }
+    let col = source.get_array(field) as number[]
+    let new_vector: boolean[] = this.cached_vector
+    if (new_vector == null){
+        new_vector = Array(col.length)
+    } else {
+        new_vector.length = col.length
+    }
+    const index_low = this.index_low
+    const index_high = this.index_high === -1 ? col.length : this.index_high
+    const [low, high] = this.range
+    for(let i=index_low; i<index_high; i++){
+        new_vector[i] = (col[i] > low) && (col[i] < high)
+    }
+    this.dirty_source = false
+    this.dirty_widget = false
+    this.cached_vector = new_vector
+    return new_vector
+  }
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -79,7 +79,7 @@ export class RangeFilter extends Model {
     const index_high = this.index_high === -1 ? col.length : this.index_high
     const [low, high] = this.range
     for(let i=index_low; i<index_high; i++){
-        new_vector[i] = (col[i] > low) && (col[i] < high)
+        new_vector[i] = (col[i] >= low) && (col[i] <= high)
     }
     this.dirty_source = false
     this.dirty_widget = false

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -60,7 +60,6 @@ RANGE_SELECTION_WIDGETS = ["slider", "range", "spinner"]
 def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     options = {
         "verbose": 0,
-        "cmapDict": None,
         "histogramList": []
     }
     options.update(kwargs)
@@ -79,7 +78,6 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     for(let i=0; i<size; ++i){
         isSelected[i] = false;
     }
-    let permutationFilter = [];
     let indicesAll = [];
     if(index != null){
         const widget = index.widget;
@@ -141,7 +139,6 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
                 isSelected &= (col[i] == widgetValue) | isOK;
             }
         }
-        // This is broken, to be fixed later.
         if(widgetType == "textQuery"){
             const queryText = widget.value;
             if(queryText == ""){
@@ -201,6 +198,7 @@ def processBokehLayoutArray(widgetLayoutDesc, widgetArray: list, widgetDict: dic
     apply layout on plain array of bokeh figures, resp. interactive widgets
     :param widgetLayoutDesc: array or dict desciption of layout
     :param widgetArray: input plain array of widgets/figures
+    :param widgetDict: input dict of widgets/figures, used for accessing them by name
     :param isHorizontal: whether to create a row or column
     :param options: options to use - can also be specified as the last element of widgetArray
     :return: combined figure
@@ -875,6 +873,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 widget.disabled = this.active
                 widget.properties.value.change.emit()
                 """))
+                if widgetFilter is not None:
+                    widgetToggle.js_on_change("active", CustomJS(args={"filter": widgetFilter}, code="""
+                    filter.change.emit()
+                    """))
                 widgetFull = row([localWidget, widgetToggle])
             else:
                 widgetFull = localWidget

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1395,7 +1395,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
         pass
     if options['callback'] == 'parameter':
         if options['type'] == 'user':
-            start = params[1], end = params[2], step = params[3]
+            start, end, step = params[1], params[2], params[3]
         else:
             param = paramDict[params[0]]
             start = param['range'][0]
@@ -1410,7 +1410,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
             value = paramDict[params[0]]["value"]
     else:
         if options['type'] == 'user':
-            start = params[1], end = params[2], step = params[3]
+            start, end, step = params[1], params[2], params[3]
         elif (options['type'] == 'auto') | (options['type'] == 'minmax'):
             start = np.nanmin(df[name])
             end = np.nanmax(df[name])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -853,9 +853,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     localWidget.js_link("value", widgetFilter, "range")
                 widgetFull = localWidget
                 if "resizeable" in optionWidget and optionWidget["resizeable"]:
-                    spinnerLow = Spinner(value=localWidget.start)
-                    spinnerHigh = Spinner(value=localWidget.end)
-                    widgetFull = row([spinnerLow, widgetFull, spinnerHigh])
+                    spinnerLow = Spinner(value=localWidget.start, title="start")
+                    spinnerLow.js_link("value", localWidget, "start")
+                    spinnerHigh = Spinner(value=localWidget.end, title="end")
+                    spinnerHigh.js_link("value", localWidget, "end")
+                    spinnerBins = Spinner(value=10, title="bins")
+                    widgetFull = layout([[spinnerLow, spinnerBins, spinnerHigh], widgetFull])
             if variables[0] == 'select':
                 localWidget = makeBokehSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
                 widgetFull = localWidget

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -107,6 +107,7 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     const t1 = performance.now();
     console.log(`Using index took ${t1 - t0} milliseconds.`);
     for (const iWidget of widgetList){
+        if(!iWidget.active) continue;
         if(iWidget.filter != null){
             if (this == iWidget.widget){
                 iWidget.filter.dirty_widget = true
@@ -884,7 +885,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 cds_used = cds_names[0]
                 if cds_used not in widgetDict:
                     widgetDict[cds_used] = {"widgetList":[]}
-                widgetDictLocal = {"widget": localWidget, "type": variables[0], "key": varName}
+                widgetDictLocal = {"widget": localWidget, "type": variables[0], "key": varName, "active": True}
                 if widgetFilter is not None:
                     widgetDictLocal["filter"] = widgetFilter
                 if "index" in optionWidget and optionWidget["index"]:
@@ -903,7 +904,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 plotDict[optionWidget["name"]] = localWidget
             if cds_used not in widgetDict:
                 widgetDict[cds_used] = {"widgetList":[]}
-            widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None})
+            widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None, "active": True})
             continue
         if variables[0] == "text":
             optionWidget = {"title": variables[1][0]}

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -867,6 +867,14 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionWidget["callback"] == "parameter":
                     active = paramDict[variables[1][0]]["value"]
                 localWidget = Toggle(label=label, active=active)
+            if variables[0] == 'spinner':
+                label = variables[1][0]
+                if "label" in optionWidget:
+                    label = optionWidget["label"]
+                value = 1
+                if optionWidget["callback"] == "parameter":
+                    value = paramDict[variables[1][0]]["value"]
+                localWidget = Spinner(title=label, value=value)
             if "toggleable" in optionWidget:
                 widgetToggle = Toggle(label="disable", active=False)
                 widgetToggle.js_on_change("active", CustomJS(args={"widget":localWidget}, code="""

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1003,7 +1003,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                         if varColor["name"] in colorMapperDict:
                             mapperC = colorMapperDict[varColor["name"]]
                         else:
-                            mapperC = {"field": varColor["name"], "transform": LinearColorMapper(palette=optionLocal['palette'],low=1,low_color=(255,255,255,0))}
+                            mapperC = {"field": varColor["name"], "transform": LinearColorMapper(palette=optionLocal['palette'])}
                             colorMapperDict[varColor["name"]] = mapperC
                     # HACK for projections - should probably just remove the rows as there's no issue with joins at all
                     if cdsDict[cds_name]["type"] == "projection" and not rescaleColorMapper and varColor["name"].split('_')[0] == 'bin':

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -853,6 +853,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     localWidget.js_link("value", widgetFilter, "range")
                 widgetFull = localWidget
                 if "resizeable" in optionWidget and optionWidget["resizeable"]:
+                    raise NotImplementedError("Resizeable sliders are not implemented yet.")
                     spinnerLow = Spinner(value=localWidget.start, title="start")
                     spinnerLow.js_link("value", localWidget, "start")
                     spinnerHigh = Spinner(value=localWidget.end, title="end")
@@ -891,6 +892,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 widgetFull = localWidget
             if variables[0] == 'spinnerRange':
                 # TODO: Make a spinner pair custom widget, or something similar
+                raise NotImplementedError("Spinner range is not implemented")
                 label = variables[1][0]
                 localWidgetMin = Spinner(title=label, value=value)
             if "toggleable" in optionWidget:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -894,7 +894,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 label = variables[1][0]
                 localWidgetMin = Spinner(title=label, value=value)
             if "toggleable" in optionWidget:
-                widgetToggle = Toggle(label="disable", active=False, width=70)
+                localWidget.disabled=True
+                widgetToggle = Toggle(label="disable", active=True, width=70)
                 widgetToggle.js_on_change("active", CustomJS(args={"widget":localWidget}, code="""
                 widget.disabled = this.active
                 widget.properties.value.change.emit()

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -107,7 +107,7 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     const t1 = performance.now();
     console.log(`Using index took ${t1 - t0} milliseconds.`);
     for (const iWidget of widgetList){
-        if(!iWidget.active) continue;
+        if(iWidget.widget.disabled) continue;
         if(iWidget.filter != null){
             if (this == iWidget.widget){
                 iWidget.filter.dirty_widget = true
@@ -874,10 +874,16 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionWidget["callback"] == "parameter":
                     active = paramDict[variables[1][0]]["value"]
                 localWidget = Toggle(label=label, active=active)
-            plotArray.append(localWidget)
+            if "toggleable" in optionWidget:
+                widgetToggle = Toggle(label="disable", active=False)
+                widgetToggle.js_link("active", localWidget, "disabled")
+                widgetFull = row([localWidget, widgetToggle])
+            else:
+                widgetFull = localWidget
+            plotArray.append(widgetFull)
             if "name" in optionWidget:
                 localWidget.name = optionWidget["name"]
-                plotDict[optionWidget["name"]] = localWidget
+                plotDict[optionWidget["name"]] = widgetFull
             if localWidget and optionWidget["callback"] != "selection":
                 widgetArray.append(localWidget)
                 widgetParams.append(variables)
@@ -885,7 +891,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 cds_used = cds_names[0]
                 if cds_used not in widgetDict:
                     widgetDict[cds_used] = {"widgetList":[]}
-                widgetDictLocal = {"widget": localWidget, "type": variables[0], "key": varName, "active": True}
+                widgetDictLocal = {"widget": localWidget, "type": variables[0], "key": varName}
                 if widgetFilter is not None:
                     widgetDictLocal["filter"] = widgetFilter
                 if "index" in optionWidget and optionWidget["index"]:
@@ -904,7 +910,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 plotDict[optionWidget["name"]] = localWidget
             if cds_used not in widgetDict:
                 widgetDict[cds_used] = {"widgetList":[]}
-            widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None, "active": True})
+            widgetDict[cds_used]["widgetList"].append({"widget": localWidget, "type": variables[0], "key": None})
             continue
         if variables[0] == "text":
             optionWidget = {"title": variables[1][0]}

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -876,7 +876,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 localWidget = Toggle(label=label, active=active)
             if "toggleable" in optionWidget:
                 widgetToggle = Toggle(label="disable", active=False)
-                widgetToggle.js_link("active", localWidget, "disabled")
+                widgetToggle.js_on_change("active", CustomJS(args={"widget":localWidget}, code="""
+                widget.disabled = this.active
+                widget.properties.value.change.emit()
+                """))
                 widgetFull = row([localWidget, widgetToggle])
             else:
                 widgetFull = localWidget

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -875,8 +875,12 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionWidget["callback"] == "parameter":
                     value = paramDict[variables[1][0]]["value"]
                 localWidget = Spinner(title=label, value=value)
+            if variables[0] == 'spinnerRange':
+                # TODO: Make a spinner pair custom widget, or something similar
+                label = variables[1][0]
+                localWidgetMin = Spinner(title=label, value=value)
             if "toggleable" in optionWidget:
-                widgetToggle = Toggle(label="disable", active=False)
+                widgetToggle = Toggle(label="disable", active=False, width=70)
                 widgetToggle.js_on_change("active", CustomJS(args={"widget":localWidget}, code="""
                 widget.disabled = this.active
                 widget.properties.value.change.emit()

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1,4 +1,3 @@
-from bisect import bisect
 from bokeh.plotting import figure, show, output_file
 from bokeh.models import ColumnDataSource, ColorBar, HoverTool, VBar, HBar, Quad
 from bokeh.models.transforms import CustomJSTransform
@@ -10,10 +9,9 @@ from RootInteractive.InteractiveDrawing.bokeh.compileVarName import getOrMakeCol
 from RootInteractive.Tools.aliTreePlayer import *
 from bokeh.layouts import *
 from bokeh.palettes import *
-from bokeh.io import push_notebook, curdoc
 import logging
 from IPython import get_ipython
-from bokeh.models.widgets import DataTable, Select, Slider, RangeSlider, MultiSelect, CheckboxGroup, Panel, Tabs, TableColumn, TextAreaInput, Toggle, Spinner
+from bokeh.models.widgets import DataTable, Select, Slider, RangeSlider, MultiSelect, CheckboxGroup, Panel, TableColumn, TextAreaInput, Toggle, Spinner
 from bokeh.models import CustomJS, ColumnDataSource
 from RootInteractive.Tools.pandaTools import pandaGetOrMakeColumn
 from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJSGraph3D

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1395,7 +1395,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
         pass
     if options['callback'] == 'parameter':
         if options['type'] == 'user':
-            start = params[1], end = params[2], step = params[3], value = (params[4], params[5])
+            start = params[1], end = params[2], step = params[3]
         else:
             param = paramDict[params[0]]
             start = param['range'][0]
@@ -1410,7 +1410,7 @@ def makeBokehSliderWidget(df: pd.DataFrame, isRange: bool, params: list, paramDi
             value = paramDict[params[0]]["value"]
     else:
         if options['type'] == 'user':
-            start = params[1], end = params[2], step = params[3], value = (params[4], params[5])
+            start = params[1], end = params[2], step = params[3]
         elif (options['type'] == 'auto') | (options['type'] == 'minmax'):
             start = np.nanmin(df[name])
             end = np.nanmax(df[name])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -845,20 +845,29 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                         target.range = [this.value-.5*this.step, this.value+.5*this.step]
                     """
                     ))
+                widgetFull = localWidget
             if variables[0] == 'range':
                 localWidget = makeBokehSliderWidget(fakeDf, True, variables[1], paramDict, **optionWidget)
                 if optionWidget["callback"] == "selection" and "index" not in optionWidget:
                     widgetFilter = RangeFilter(range=localWidget.value, field=variables[1][0], name=variables[1][0])
                     localWidget.js_link("value", widgetFilter, "range")
+                widgetFull = localWidget
+                if "resizeable" in optionWidget and optionWidget["resizeable"]:
+                    spinnerLow = Spinner(value=localWidget.start)
+                    spinnerHigh = Spinner(value=localWidget.end)
+                    widgetFull = row([spinnerLow, widgetFull, spinnerHigh])
             if variables[0] == 'select':
                 localWidget = makeBokehSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
+                widgetFull = localWidget
             if variables[0] == 'multiSelect':
                 localWidget, widgetFilter, newColumn = makeBokehMultiSelectWidget(fakeDf, variables[1], paramDict, **optionWidget)
                 if newColumn is not None:
                     memoized_columns[None][newColumn["name"]] = newColumn
                     sources.add((None, newColumn["name"]))
+                widgetFull = localWidget
             if variables[0] == 'multiSelectBitmask':
                 localWidget, widgetFilter = makeBokehMultiSelectBitmaskWidget(column[0], **optionWidget)
+                widgetFull = localWidget
             if variables[0] == 'toggle':
                 label = variables[1][0]
                 if "label" in optionWidget:
@@ -867,6 +876,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionWidget["callback"] == "parameter":
                     active = paramDict[variables[1][0]]["value"]
                 localWidget = Toggle(label=label, active=active)
+                widgetFull = localWidget
             if variables[0] == 'spinner':
                 label = variables[1][0]
                 if "label" in optionWidget:
@@ -875,6 +885,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if optionWidget["callback"] == "parameter":
                     value = paramDict[variables[1][0]]["value"]
                 localWidget = Spinner(title=label, value=value)
+                widgetFull = localWidget
             if variables[0] == 'spinnerRange':
                 # TODO: Make a spinner pair custom widget, or something similar
                 label = variables[1][0]
@@ -889,9 +900,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     widgetToggle.js_on_change("active", CustomJS(args={"filter": widgetFilter}, code="""
                     filter.change.emit()
                     """))
-                widgetFull = row([localWidget, widgetToggle])
-            else:
-                widgetFull = localWidget
+                widgetFull = row([widgetFull, widgetToggle])
             plotArray.append(widgetFull)
             if "name" in optionWidget:
                 localWidget.name = optionWidget["name"]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -254,4 +254,4 @@ def testJoin():
     
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, sourceArray=sourceArray, aliasArray=aliasArray)
-
+    

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -75,15 +75,15 @@ tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)
 
 widgetParams=[
     ['range', ['A']],
-    ['range', ['B', 0, 1, 0.1, 0, 1], {"index": True}],
+    ['range', ['B', 0, 1, 0.1, 0, 1], {"type":"user", "index": True}],
 
-    ['range', ['C'], {'type': 'minmax'}],
+    ['range', ['C'], {'type': 'minmax', "toggleable":True}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10, "toggleable":True}],
     ['multiSelect', ["DDC", "A2", "A3", "A4", "A0", "A1"]],
     ['multiSelectBitmask', ["maskAC"], {"mapping": {"A": 2, "C": 1}, "how":"all", "title": "maskAC(all)"}],
-    ['select',["CC", 0, 1, 2, 3], {"default": 1}],
+    ['select',["CC", 0, 1, 2, 3], {"default": 1, "toggleable":True}],
     ['multiSelect',["BoolB"]],
     ['textQuery', {"title": "selection", "name":"selectionText"}],
     #['slider','F', ['@min()','@max()','@med','@min()','@median()+3*#tlm()']], # to be implmneted

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -80,7 +80,7 @@ widgetParams=[
     ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
-    ['slider', ['AA'], {'bins': 10}],
+    ['slider', ['AA'], {'bins': 10, "toggleable":True}],
     ['multiSelect', ["DDC", "A2", "A3", "A4", "A0", "A1"]],
     ['multiSelectBitmask', ["maskAC"], {"mapping": {"A": 2, "C": 1}, "how":"all", "title": "maskAC(all)"}],
     ['select',["CC", 0, 1, 2, 3], {"default": 1}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -77,7 +77,7 @@ widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1], {"index": True}],
 
-    ['range', ['C'], {'type': 'minmax'}],
+    ['range', ['C'], {'type': 'minmax', "resizeable": True, "toggleable":True}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10, "toggleable":True}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -92,7 +92,7 @@ widgetParams=[
     ['slider',["size"], {"name": "markerSize"}],
     ['select',["legendFontSize"], {"name": "legendFontSize"}],
     ['toggle', ['legendVisible'], {"name": "legendVisible"}],
-    ['slider', ['nPoints'], {"name": "nPointsRender"}]
+    ['spinner', ['nPoints'], {"name": "nPointsRender"}]
 ]
 
 widgetLayoutDesc={

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -77,7 +77,7 @@ widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1], {"index": True}],
 
-    ['range', ['C'], {'type': 'minmax', "resizeable": True, "toggleable":True}],
+    ['range', ['C'], {'type': 'minmax'}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10, "toggleable":True}],


### PR DESCRIPTION
This PR:
- Reverts the color mapper minimum change from #230 - bins with entries below 1 not being drawn caused side effects if color axis was used for anything that could take values less than 1
- Adds the "toggleable" option to slider and select widgets- not supported for MultiSelect widgets as disabled option is not supported for them
- Refactors makeJSCallback - more preparations to replace with a smarter solution
- Adds support for spinner widgets - so far they can only control parameters in parameterArray