### PR TITLE
Spinner range widget

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
@@ -1,13 +1,12 @@
 from bokeh.model import Model
-from bokeh.core.properties import Instance, String, Dict, List, Any, Int
-from bokeh.models.widgets import MultiSelect
+from bokeh.core.properties import Instance, String, Dict, List, Int
 from bokeh.models.sources import ColumnarDataSource
 
 class MultiSelectFilter(Model):
     __implementation__ = "MultiSelectFilter.ts"
 
     source = Instance(ColumnarDataSource, help="Column data source to select from")
-    widget = Instance(MultiSelect, help="MultiSelect controlling the filter")
+    selected = List(String, help="Selected values")
     mapping = Dict(String, Int, help="Dictionary converting labels to values to use")
     mask = Int(default=-1, help="AND mask to apply before using multiselect")
     field = String(help="The field to check")

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1518,14 +1518,16 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
         for i, val in enumerate(optionsPlot):
             mapping[val] = 2**i
         # print(optionsPlot)
-        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="any", mapping=mapping)
+        filterLocal = MultiSelectFilter(selected=optionsPlot, field=params[0]+".factor()", how="any", mapping=mapping)
+        widget_local.js_link("value", filterLocal, "selected")
         newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": (2**codes).astype(np.int32)}
     else:
         mapping = {}
         for i, val in enumerate(optionsPlot):
             mapping[val] = i
         print(len(optionsPlot))
-        filterLocal = MultiSelectFilter(widget=widget_local, field=params[0]+".factor()", how="whitelist", mapping=mapping)
+        filterLocal = MultiSelectFilter(selected=optionsPlot, field=params[0]+".factor()", how="whitelist", mapping=mapping)
+        widget_local.js_link("value", filterLocal, "selected")
         newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes.astype(np.int32)}
     return widget_local, filterLocal, newColumn
 
@@ -1538,9 +1540,10 @@ def makeBokehMultiSelectBitmaskWidget(column: dict, title: str, mapping: dict, *
         multiselect_value = keys
     else:
         multiselect_value = []
-    widgetLocal = MultiSelect(title=title, value=multiselect_value, options=keys, size=options["size"])
-    filterLocal = MultiSelectFilter(widget=widgetLocal, field=column["name"], how=options["how"], mapping=mapping)
-    return widgetLocal, filterLocal
+    widget_local = MultiSelect(title=title, value=multiselect_value, options=keys, size=options["size"])
+    filter_local = MultiSelectFilter(selected=multiselect_value, field=column["name"], how=options["how"], mapping=mapping)
+    widget_local.js_link("value", filter_local, "selected")
+    return widget_local, filter_local
 
 
 def makeBokehCheckboxWidget(df: pd.DataFrame, params: list, paramDict: dict, **kwargs):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -11,7 +11,7 @@ from bokeh.layouts import *
 from bokeh.palettes import *
 import logging
 from IPython import get_ipython
-from bokeh.models.widgets import DataTable, Select, Slider, RangeSlider, MultiSelect, CheckboxGroup, Panel, TableColumn, TextAreaInput, Toggle, Spinner, RadioButtonGroup
+from bokeh.models.widgets import DataTable, Select, Slider, RangeSlider, MultiSelect, Panel, TableColumn, TextAreaInput, Toggle, Spinner, RadioButtonGroup
 from bokeh.models import CustomJS, ColumnDataSource
 from RootInteractive.Tools.pandaTools import pandaGetOrMakeColumn
 from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJSGraph3D
@@ -126,13 +126,6 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
                 let isOK = Math.abs(col[i] - widgetValue) <= widgetValue * precision;
                 isOK|=(col[i] == widgetValue)
                 isSelected[i] &= (col[i] == widgetValue) | isOK;
-            }
-        }
-        if(widgetType == "CheckboxGroup"){
-            const widgetValue = widget.value;
-            for(let i=first; i<last; i++){
-                isOK = Math.abs(col[i] - widgetValue) <= widgetValue * precision;
-                isSelected &= (col[i] == widgetValue) | isOK;
             }
         }
         if(widgetType == "textQuery"){
@@ -1546,23 +1539,6 @@ def makeBokehMultiSelectBitmaskWidget(column: dict, title: str, mapping: dict, *
     return widget_local, filter_local
 
 
-def makeBokehCheckboxWidget(df: pd.DataFrame, params: list, paramDict: dict, **kwargs):
-    options = {'default': 0, 'size': 10}
-    options.update(kwargs)
-    # optionsPlot = []
-    if len(params) == 1:
-        optionsPlot = np.sort(df[params[0]].unique()).tolist()
-    else:
-        optionsPlot = params[1:]
-    for i, val in enumerate(optionsPlot):
-        optionsPlot[i] = str(val)
-    return CheckboxGroup(labels=optionsPlot, active=[])
-
-
-def makeBokehSpinnerWidget():
-    return Spinner()
-
-
 def connectWidgetCallbacks(widgetParams: list, widgetArray: list, paramDict: dict, defaultCallback: CustomJS):
     for iDesc, iWidget in zip(widgetParams, widgetArray):
         optionLocal = {}
@@ -1588,9 +1564,7 @@ def connectWidgetCallbacks(widgetParams: list, widgetArray: list, paramDict: dic
                     iWidget.js_link(*iEvent)
             continue
         if callback is not None:
-            if isinstance(iWidget, CheckboxGroup):
-                iWidget.js_on_click(callback)
-            elif isinstance(iWidget, Slider) or isinstance(iWidget, RangeSlider):
+            if isinstance(iWidget, Slider) or isinstance(iWidget, RangeSlider):
                 iWidget.js_on_change("value", callback)
             else:
                 iWidget.js_on_change("value", callback)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -77,7 +77,7 @@ widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1], {"type":"user", "index": True}],
 
-    ['range', ['C'], {'type': 'minmax', "toggleable":True}],
+    ['spinnerRange', ['C'], {}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
     ['slider', ['AA'], {'bins': 10, "toggleable":True}],


### PR DESCRIPTION
This PR adds a new widget - spinnerRange
The widget consists of two spinners, with step size so far hardcoded to be 5% of max-min - this can be changed but there might be technical issues
This PR also refactors the select widget, removing it from makeJSCallback, only leaving the logic for textinput there
Example use in test_bokehDrawSA.py

```
widgetParams=[
    ['spinnerRange', ['C']]
]
```