### PR TITLE
Spinner range bugfix

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1497,22 +1497,14 @@ def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, defau
     """
     if options['callback'] == 'parameter':
         return widget_local, filterLocal, newColumn
-    if len(optionsPlot) < 31:
-        mapping = {}
-        for i, val in enumerate(optionsPlot):
-            mapping[val] = 2**i
-        # print(optionsPlot)
-        filterLocal = MultiSelectFilter(selected=optionsPlot, field=params[0]+".factor()", how="any", mapping=mapping)
-        widget_local.js_on_change("value", CustomJS(args={"target":filterLocal}, code=js_callback_code))
-        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": (2**codes).astype(np.int32)}
-    else:
-        mapping = {}
-        for i, val in enumerate(optionsPlot):
-            mapping[val] = i
-        print(len(optionsPlot))
-        filterLocal = MultiSelectFilter(selected=optionsPlot, field=params[0]+".factor()", how="whitelist", mapping=mapping)
-        widget_local.js_on_change("value", CustomJS(args={"target":filterLocal}, code=js_callback_code))
-        newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes.astype(np.int32)}
+
+    mapping = {}
+    for i, val in enumerate(optionsPlot):
+        mapping[val] = i
+    print(len(optionsPlot))
+    filterLocal = MultiSelectFilter(selected=optionsPlot, field=params[0]+".factor()", how="whitelist", mapping=mapping)
+    widget_local.js_on_change("value", CustomJS(args={"target":filterLocal}, code=js_callback_code))
+    newColumn = {"name": params[0]+".factor()", "type": "server_derived_column", "value": codes.astype(np.int32)}
     return widget_local, filterLocal, newColumn
 
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -902,7 +902,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             if "name" in optionWidget:
                 plotDict[optionWidget["name"]] = widgetFull
             if localWidget and optionWidget["callback"] != "selection":
-                widgetArray.append(localWidget)
+                widgetArray.append(widgetFull)
                 widgetParams.append(variables)
             if optionWidget["callback"] == "selection":
                 cds_used = cds_names[0]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -900,7 +900,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 widgetFull = row([widgetFull, widgetToggle])
             plotArray.append(widgetFull)
             if "name" in optionWidget:
-                localWidget.name = optionWidget["name"]
                 plotDict[optionWidget["name"]] = widgetFull
             if localWidget and optionWidget["callback"] != "selection":
                 widgetArray.append(localWidget)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -878,7 +878,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     other.step = this.step = (this.value - other.value) * .05
                     filter.properties.range.change.emit()
                     """))
-                widgetFull=row([localWidgetMin, localWidgetMax])
+                widgetFull=localWidget=row([localWidgetMin, localWidgetMax])
             if "toggleable" in optionWidget:
                 widgetToggle = Toggle(label="disable", active=True, width=70)
                 if variables[0] == 'spinnerRange':

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -880,7 +880,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     """))
                 widgetFull=row([localWidgetMin, localWidgetMax])
             if "toggleable" in optionWidget:
-                localWidget.disabled=True
                 widgetToggle = Toggle(label="disable", active=True, width=70)
                 if variables[0] == 'spinnerRange':
                     widgetToggle.js_on_change("active", CustomJS(args={"widgetMin":localWidgetMin, "widgetMax": localWidgetMax, "filter": widgetFilter}, code="""
@@ -889,6 +888,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     filter.change.emit()
                     """))
                 else:
+                    localWidget.disabled=True
                     widgetToggle.js_on_change("active", CustomJS(args={"widget":localWidget}, code="""
                     widget.disabled = this.active
                     widget.properties.value.change.emit()
@@ -901,8 +901,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
             plotArray.append(widgetFull)
             if "name" in optionWidget:
                 plotDict[optionWidget["name"]] = widgetFull
-            if localWidget and optionWidget["callback"] != "selection":
-                widgetArray.append(widgetFull)
+            if optionWidget["callback"] != "selection" and localWidget:
+                widgetArray.append(localWidget)
                 widgetParams.append(variables)
             if optionWidget["callback"] == "selection":
                 cds_used = cds_names[0]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -77,10 +77,10 @@ widgetParams=[
     ['range', ['A']],
     ['range', ['B', 0, 1, 0.1, 0, 1], {"type":"user", "index": True}],
 
-    ['spinnerRange', ['C'], {}],
+    ['spinnerRange', ['C'], {"name": "widgetC"}],
     ['range', ['D'], {'type': 'sigma', 'bins': 10, 'sigma': 3}],
     ['range', ['E'], {'type': 'sigmaMed', 'bins': 10, 'sigma': 3}],
-    ['slider', ['AA'], {'bins': 10, "toggleable":True}],
+    ['slider', ['AA'], {'bins': 10, "toggleable":True, "name": "widgetAA"}],
     ['multiSelect', ["DDC", "A2", "A3", "A4", "A0", "A1"]],
     ['multiSelectBitmask', ["maskAC"], {"mapping": {"A": 2, "C": 1}, "how":"all", "title": "maskAC(all)"}],
     ['select',["CC", 0, 1, 2, 3], {"default": 1, "toggleable":True}],
@@ -96,7 +96,7 @@ widgetParams=[
 ]
 
 widgetLayoutDesc={
-    "Selection": [[0, 1, 2], [3, 4], [5, 6],[7,8, "selectionText"], {'sizing_mode': 'scale_width'}],
+    "Selection": [[0, 1, "widgetC"], [3, 4], ["widgetAA", 6],[7,8, "selectionText"], {'sizing_mode': 'scale_width'}],
     "Graphics": [["colorZ", "X", "markerSize"], ["legendFontSize", "legendVisible", "nPointsRender"], {'sizing_mode': 'scale_width'}]
     }
 


### PR DESCRIPTION
This PR:
- Fixes spinner range not working with Python 3.8 because of unbound variable error
- Removes convoluted bitmask based logic from the select widget (now uses a simple comparison)