### PR TITLE
Anonymous custom JS expressions

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -118,7 +118,7 @@ export class CDSAlias extends ColumnarDataSource {
             }            
         } else{
             new_column = []
-            for (let i = 0; i < fields[0].length; i++) {
+            for (let i = 0; i < len; i++) {
                 const row = fields.map((x: any[]) => x[i])
                 // This will likely have very bad performance
                 new_column.push(column.transform.compute(row))

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -532,7 +532,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     paramDict[i["func"]]["subscribed_events"].append(["value", CustomJS(args={"mapper":transform}, code="""
             mapper.func = this.value
             mapper.update_func()
-            mapper.change.emit()
                     """)])
                 else:
                     transform = CustomJSNAryFunction(parameters=customJsArgList, fields=i["variables"], func=i["func"])

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -74,6 +74,8 @@ class ColumnEvaluator:
             return self.visit_UnaryOp(node)
         elif isinstance(node, ast.Compare):
             return self.visit_Compare(node)
+        elif isinstance(node, ast.BoolOp):
+            return self.visit_BoolOp(node)
         else:
             return self.eval_fallback(node)
 
@@ -350,6 +352,19 @@ class ColumnEvaluator:
                 raise NotImplementedError(f"Binary operator {ast.dump(op)} not implemented for expressions on the client")
             js_comparisons.append(f"(({lhs}){op_infix}({rhs}))")
         implementation = " && ".join(js_comparisons)
+        return {
+            "name": self.code,
+            "type": "javascript",
+            "implementation": implementation
+        }
+    
+    def visit_BoolOp(self, node:ast.BoolOp):
+        js_values = [f"({self.visit(i)['implementation']})" for i in node.values]
+        if isinstance(node.op, ast.And):
+            op_infix = " && "
+        elif isinstance(node.op, ast.Or):
+            op_infix = " || "
+        implementation = op_infix.join(js_values)
         return {
             "name": self.code,
             "type": "javascript",

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -1,11 +1,26 @@
 import ast
 import numpy as np
 
-# This is not used yet - will be used when aliases will be able to use generated javascript code
+from RootInteractive.InteractiveDrawing.bokeh.CustomJSNAryFunction import CustomJSNAryFunction
+
 JAVASCRIPT_GLOBALS = {
     "sin": "Math.sin",
     "cos": "Math.cos",
-    "log": "Math.log"
+    "arcsin": "Math.asin",
+    "arccos": "Math.acos",
+    "arctan": "Math.atan",
+    "exp": "Math.exp",
+    "log": "Math.log",
+    "log2": "Math.log2",
+    "log10": "Math.log10",
+    "sqrt": "Math.sqrt",
+    "abs": "Math.abs",
+    "sinh": "Math.sinh",
+    "cosh": "Math.cosh",
+    "arctan2": "Math.atan2",
+    "arccosh": "Math.acosh",
+    "arcsinh": "Math.asinh",
+    "arctanh": "Math.atanh"
 }
 
 math_functions = {
@@ -36,6 +51,8 @@ class ColumnEvaluator:
         self.funcDict = funcDict
         self.context = context
         self.dependencies = set()
+        self.paramDependencies = set()
+        self.aliasDependencies = set()
         self.firstGeneratedID = firstGeneratedID
         self.code = code
         self.isSource = True 
@@ -50,6 +67,8 @@ class ColumnEvaluator:
             return self.visit_Name(node)
         elif isinstance(node, ast.Num):
             return self.visit_Num(node)
+        elif isinstance(node, ast.BinOp):
+            return self.visit_BinOp(node)
         else:
             return self.eval_fallback(node)
 
@@ -77,6 +96,11 @@ class ColumnEvaluator:
                 args.append(self.visit(iArg))
                 implementation += args[-1]["implementation"]
             implementation += ')'
+            return {
+                "implementation": implementation,
+                "type": "javascript",
+                "name": self.code
+            }
         return self.eval_fallback(node)
 
     def visit_Num(self, node: ast.Num):
@@ -84,6 +108,7 @@ class ColumnEvaluator:
         self.isSource = False
         return {
             "name": str(node.n),
+            "implementation": str(node.n),
             "type": "constant",
             "value": node.n
         }
@@ -98,13 +123,16 @@ class ColumnEvaluator:
                 self.dependencies.add((self.context, self.aliasDict[self.context][node.attr]))
                 return {
                     "name": node.attr,
+                    "implementation": node.attr,
                     "type": "alias"
                 }
             if "fields" in self.aliasDict[self.context][node.attr]:
                 for i in self.aliasDict[self.context][node.attr]["fields"]:
                     self.dependencies.add((self.context, i))
+            self.aliasDependencies.add(node.attr)
             return {
                 "name": node.attr,
+                "implementation": node.attr,
                 "type": "alias"
             }
         if self.cdsDict[self.context]["type"] == "join":
@@ -115,6 +143,7 @@ class ColumnEvaluator:
             if node.attr in self.cdsDict:
                 return {
                     "name": node.attr,
+                    "implementation": node.attr,
                     "type": "table",
                     "attrChain": attrChain + [node.attr]
                 }
@@ -131,8 +160,10 @@ class ColumnEvaluator:
             if(cds_used < len(attrChain)):
                 if attrChain[cds_used] in [cds["left"], cds["right"]]:
                     self.dependencies.add((attrChain[cds_used], node.attr))
+            self.aliasDependencies.add(node.attr)
             return {
                 "name": node.attr,
+                "implementation": node.attr,
                 "type": "column"
             }
         if not isinstance(node.value, ast.Name):
@@ -156,8 +187,10 @@ class ColumnEvaluator:
             #    "error": KeyError,
             #    "msg": "Column " + id + " not found in data source " + self.cdsDict[self.context]["name"]
             #}           
+        self.aliasDependencies.add(node.attr)
         return {
             "name": node.attr,
+            "implementation": node.attr,
             "type": "column"
         }
 
@@ -168,8 +201,10 @@ class ColumnEvaluator:
             if "options" in self.paramDict[node.id]:
                 for iOption in self.paramDict[node.id]["options"]:
                     self.dependencies.add((self.context, iOption))
+            self.paramDependencies.add(node.id)
             return {
                 "name": node.id,
+                "implementation": node.id,
                 "type": "parameter"
             }
         if node.id in [self.context, "self"]:
@@ -216,8 +251,10 @@ class ColumnEvaluator:
             #    "error": KeyError,
             #    "msg": "Column " + id + " not found in histogram " + histogram["name"]
             #}
+        self.aliasDependencies.add(id)
         return {
             "name": id,
+            "implementation": id,
             "type": "column"
         }        
 
@@ -235,6 +272,41 @@ class ColumnEvaluator:
             "value": eval(code, {}, locals),
             "type": "server_derived_column"
             }
+
+    def visit_BinOp(self, node):
+        if "data" in self.cdsDict[self.context]:
+            return self.eval_fallback(node)
+        op = node.op
+        if isinstance(op, ast.Add):
+            operator_infix = " + "
+        elif isinstance(op, ast.Sub):
+            operator_infix = " - "
+        elif isinstance(op, ast.Mult):
+            operator_infix = " * "
+        elif isinstance(op, ast.Div):
+            operator_infix = " / "
+        elif isinstance(op, ast.Mod):
+            operator_infix = " % "
+        elif isinstance(op, ast.LShift):
+            operator_infix = " << "
+        elif isinstance(op, ast.RShift):
+            operator_infix = " >> "
+        elif isinstance(op, ast.RShift):
+            operator_infix = " >> "
+        elif isinstance(op, ast.BitOr):
+            operator_infix = " | "
+        elif isinstance(op, ast.BitXor):
+            operator_infix = " ^ "
+        elif isinstance(op, ast.BitAnd):
+            operator_infix = " & "
+        else:
+            raise NotImplementedError(f"Binary operator {ast.dump(op)} not implemented for expressions on the client")
+        implementation = f"({self.visit(node.left)['implementation']}){operator_infix}({self.visit(node.right)['implementation']})"
+        return {
+            "name": self.code,
+            "type": "javascript",
+            "implementation": implementation
+        }
         
 
 def checkColumn(columnKey, tableKey, cdsDict):
@@ -260,7 +332,7 @@ def getOrMakeColumns(variableNames, context = None, cdsDict: dict = {}, paramDic
     for i in range(max(len(variableNames), len(context))):
         i_var = variableNames[i % nvars]
         i_context = context[i % n_context] 
-        if i_context == "$IGNORE":
+        if i_context in ["$IGNORE", "auto"]:
             variables.append(None)
             ctx_updated.append(i_context)
             continue
@@ -274,8 +346,22 @@ def getOrMakeColumns(variableNames, context = None, cdsDict: dict = {}, paramDic
         queryAST = ast.parse(i_var, mode="eval")
         evaluator = ColumnEvaluator(i_context, cdsDict, paramDict, funcDict, i_var, aliasDict)
         column = evaluator.visit(queryAST.body)
-        variables.append(column)
         i_context = evaluator.context
+        if column["type"] == "javascript":
+            if aliasDict is not None:
+                if i_context not in aliasDict:
+                    aliasDict[i_context] = {}
+                columnName = column["name"]
+                func = "return "+column["implementation"]
+                variablesAlias = list(evaluator.aliasDependencies)
+                transform = CustomJSNAryFunction(parameters={}, fields=variablesAlias, func=func)
+                aliasDict[i_context][columnName] = {"transform": transform, "fields": variablesAlias}
+                newColumn = {
+                    "type": "alias",
+                    "name": columnName
+                }
+                column = newColumn
+        variables.append(column)
         if evaluator.isSource:
             used_names.update({(i_context, column["name"])})
         else:

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -69,6 +69,8 @@ class ColumnEvaluator:
             return self.visit_Num(node)
         elif isinstance(node, ast.BinOp):
             return self.visit_BinOp(node)
+        elif isinstance(node, ast.UnaryOp):
+            return self.visit_UnaryOp(node)
         else:
             return self.eval_fallback(node)
 
@@ -308,6 +310,22 @@ class ColumnEvaluator:
             "implementation": implementation
         }
         
+    def visit_UnaryOp(self, node: ast.UnaryOp):
+        if "data" in self.cdsDict[self.context]:
+            return self.eval_fallback(node)
+        op = node.op
+        if isinstance(op, ast.UAdd):
+            operator_prefix = "+"
+        elif isinstance(op, ast.USub):
+            operator_prefix = "-"
+        else:
+            operator_prefix = "!"
+        implementation = f"{operator_prefix}({self.visit(node.operand)['implementation']})"
+        return {
+            "name": self.code,
+            "type": "javascript",
+            "implementation": implementation
+        }
 
 def checkColumn(columnKey, tableKey, cdsDict):
     return False

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -180,11 +180,13 @@ def test_makeColumns():
     paramDict = {"paramA": {"value": "5"}}
     functionDict = {"saxpy": {"name": "saxpy", "fields": ["a", "x", "y"]}}
     cdsDict = {"histoA": {"nbins": 10, "type": "histogram", "variables": ["X"], "source": None}, None: {"data": df, "type": "source"}}
+    aliasDict={}
     varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["1", "Y", "10*X+Y", "Y", "X*(Y**(5/2))", "X*(Y**(5/2))/Z", "sqrt(X)","paramA", "histoA.bin_count"], None, cdsDict, paramDict, functionDict)
     assert len(varList) == 9
     assert len(sources) == 6
     assert ctx_updated[-1] == "histoA"
-    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["log(1+bin_count)"], ["histoA"], cdsDict, paramDict, functionDict)
+    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["log(1+bin_count)", "-1<=-bin_count<1"], ["histoA"], cdsDict, paramDict, functionDict, aliasDict=aliasDict)
     print(ctx_updated)
     print(memoized_columns)
     print(sources)
+    print(aliasDict)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -180,11 +180,12 @@ def test_customJsFunctionBokehDrawArray_v():
 def test_makeColumns():
     varList, ctx_updated, memoized_columns, sources = (None, None, None, None)
     df = pd.DataFrame(np.random.random_sample(size=(200000, 3)), columns=list('XYZ'))
+    df["boolY"] = df.eval("Y<Z")
     paramDict = {"paramA": {"value": "5"}}
     functionDict = {"saxpy": {"name": "saxpy", "fields": ["a", "x", "y"]}}
     cdsDict = {"histoA": {"nbins": 10, "type": "histogram", "variables": ["X"], "source": None}, None: {"data": df, "type": "source"}}
     aliasDict={}
-    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["1", "Y", "10*X+Y", "Y", "X*(Y**(5/2))", "X*(Y**(5/2))/Z", "sqrt(X)","paramA", "histoA.bin_count", "X<paramA"], None, cdsDict, paramDict, functionDict, aliasDict=aliasDict)
+    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["1", "Y", "10*X+Y", "Y", "X*(Y**(5/2))", "X*(Y**(5/2))/Z", "sqrt(X)","paramA", "histoA.bin_count", "X<paramA or boolY"], None, cdsDict, paramDict, functionDict, aliasDict=aliasDict)
     assert len(varList) == 10
     assert len(sources) == 7
     assert ctx_updated[-2] == "histoA"
@@ -193,3 +194,5 @@ def test_makeColumns():
     print(memoized_columns)
     print(sources)
     print(aliasDict)
+
+test_makeColumns()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -51,14 +51,14 @@ aliasArray = [
     },
     {
         "name": "efficiency_A",
-        "variables": ["entries", "entries_C_cut"],
-        "func": "return entries_C_cut / entries",
+        "variables": ["bin_count", "entries_C_cut"],
+        "func": "return entries_C_cut / bin_count",
         "context": "histoA"
     },
     {
         "name": "efficiency_AC",
-        "variables": ["entries", "entries_C_cut"],
-        "func": "return entries_C_cut / entries",
+        "variables": ["bin_count", "entries_C_cut"],
+        "func": "return entries_C_cut / bin_count",
         "context": "histoAC"
     },
     {
@@ -70,9 +70,9 @@ aliasArray = [
 
 figureArray = [
     [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B', "custom_column"], {"size":"size"}],
-    [['histoA.bin_center'], ['efficiency_A'], {"context":"histoA", "size":"size"}],
-    [['histoA.bin_center'], ['histoA.entries', 'histoA.entries_C_cut'], {"context":"histoA", "size":"size"}],
-    [['histoAC.bin_center_0'], ['efficiency_AC'], {"context":"histoAC", "size":"size", "colorZvar": "histoAC.bin_center_1"}],
+    [['bin_center'], ['efficiency_A', 'entries_C_cut / bin_count'], {"source":"histoA", "size":"size"}],
+    [['bin_center'], ['bin_count', 'entries_C_cut'], {"source":"histoA", "size":"size", "errY":["sqrt(bin_count)","sqrt(entries_C_cut)"]}],
+    [['bin_center_0'], ['efficiency_AC'], {"source":"histoAC", "size":"size", "colorZvar": "bin_center_1"}],
     {"size":"size", "legend_options": {"label_text_font_size": "legendFontSize"}}
 ]
 
@@ -184,6 +184,7 @@ def test_makeColumns():
     assert len(varList) == 9
     assert len(sources) == 6
     assert ctx_updated[-1] == "histoA"
+    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["log(1+bin_count)"], ["histoA"], cdsDict, paramDict, functionDict)
     print(ctx_updated)
     print(memoized_columns)
     print(sources)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -70,8 +70,8 @@ aliasArray = [
 
 figureArray = [
     [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B', "custom_column"], {"size":"size"}],
-    [['bin_center'], ['efficiency_A', 'entries_C_cut / bin_count'], {"source":"histoA", "size":"size"}],
-    [['bin_center'], ['bin_count', 'entries_C_cut'], {"source":"histoA", "size":"size", "errY":["sqrt(bin_count)","sqrt(entries_C_cut)"]}],
+    [['bin_center'], ['efficiency_A', 'entries_C_cut / bin_count', "C_accepted/bin_count"], {"source":"histoA", "size":"size"}],
+    [['bin_center'], ['bin_count', 'entries_C_cut', "C_accepted"], {"source":"histoA", "size":"size", "errY":["sqrt(bin_count)","sqrt(entries_C_cut)","sqrt(C_accepted)"]}],
     [['bin_center_0'], ['efficiency_AC'], {"source":"histoAC", "size":"size", "colorZvar": "bin_center_1"}],
     {"size":"size", "legend_options": {"label_text_font_size": "legendFontSize"}}
 ]
@@ -82,6 +82,9 @@ histoArray = [
             "entries": None,
             "entries_C_cut": {
                 "weights": "C_accepted"
+            },
+            "C_accepted": {
+                "weights": "C < C_cut"
             }
         }
     },
@@ -181,10 +184,10 @@ def test_makeColumns():
     functionDict = {"saxpy": {"name": "saxpy", "fields": ["a", "x", "y"]}}
     cdsDict = {"histoA": {"nbins": 10, "type": "histogram", "variables": ["X"], "source": None}, None: {"data": df, "type": "source"}}
     aliasDict={}
-    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["1", "Y", "10*X+Y", "Y", "X*(Y**(5/2))", "X*(Y**(5/2))/Z", "sqrt(X)","paramA", "histoA.bin_count"], None, cdsDict, paramDict, functionDict)
-    assert len(varList) == 9
-    assert len(sources) == 6
-    assert ctx_updated[-1] == "histoA"
+    varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["1", "Y", "10*X+Y", "Y", "X*(Y**(5/2))", "X*(Y**(5/2))/Z", "sqrt(X)","paramA", "histoA.bin_count", "X<paramA"], None, cdsDict, paramDict, functionDict, aliasDict=aliasDict)
+    assert len(varList) == 10
+    assert len(sources) == 7
+    assert ctx_updated[-2] == "histoA"
     varList, ctx_updated, memoized_columns, sources = getOrMakeColumns(["log(1+bin_count)", "-1<=-bin_count<1"], ["histoA"], cdsDict, paramDict, functionDict, aliasDict=aliasDict)
     print(ctx_updated)
     print(memoized_columns)


### PR DESCRIPTION
This PR:
-Fixes a bug that made aliases with no input variables crash
-Adds anonymous custom JS expressions - example:
```
figureArray=[
    [['bin_center'], ['eff_isOK', 'isOK / bin_count'], {"source":"histoA", "size":"size", "errY":"sqrt(isOK)/bin_count"}],
]
```
Supported expressions:
Binary operations - add, sub, mult, div, mod, lshift, rshift, or, xor, and
Numpy ufuncs / javascript Math functions - sin, cos, arcsin, arccos, arctan, exp, log, log2, log10, sqrt, abs, sinh, cosh, arcsinh, arccosh, arctan2
Unary operations - uadd, usub, not
Comparators (Python style, converted to Javascript style) - ==, !=, <, <=, >, >=
Parameters in parameterArray

WISH:
- Add support for reducers (sum, mean, std, subscript, ...)