### PR TITLE
Less verbose aliasArray interface

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -514,6 +514,11 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
     for i in aliasArray:
         customJsArgList = {}
         transform = None
+        if not isinstance(i, dict):
+            if len(i) == 2:
+                i = {"name":i[0], "expr":i[1]}
+            if len(i) == 3:
+                i = {"name":i[0], "expr":i[1], "context": i[2]}
         aliasSet.add(i["name"])
         if "transform" in i:
             if i["transform"] in jsFunctionDict:

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -45,9 +45,7 @@ aliasArray = [
     },
     {
         "name": "C_accepted",
-        "variables": ["C"],
-        "parameters": ["C_cut"],
-        "func": "return C < C_cut"
+        "expr": "C < C_cut"
     },
     {
         "name": "efficiency_A",

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -268,12 +268,7 @@ def test_StableQuantile():
         {"name": "projection3D_weight", "axis_idx":[2], "source": "histo3D_weight", "unbinned":True, "type":"projection", "quantiles": [.05, .5, .95], "weights":"1+A"}
     ]
     aliasArray = [
-        {
-            "name": f"{i}_normed",
-            "variables": [i, "bin_center_0"],
-            "func": f"return {i} / bin_center_0**2",
-            "context": j
-        } for i in ["mean", "std", "quantile_0",  "quantile_1", "quantile_2"] for j in ["histoAB_1", "histoABWeight_1", "projectionA", "projectionAWeight"]
+        (f"{i}_normed", f"{i} / bin_center_0**2", j) for i in ["mean", "std", "quantile_0",  "quantile_1", "quantile_2"] for j in ["histoAB_1", "histoABWeight_1", "projectionA", "projectionAWeight"]
     ]
     aliasArray += [
         {


### PR DESCRIPTION
This PR:
- Refactors bokehDrawArray by extracting a method
- Adds an "expr" parameter to aliases - takes a string input which is converted to javascript and has auto detected input parameters
- Adds a less verbose interface for aliases - a (name, expr, table) tuple - examples in test_bokehClientHistogram.py and test_Alias.py

Simple example
```python
aliasArray=[
  ("errX", "sqrt(X)"),
  ("logX", "log(X)")
]
```

Example using loop
```python
    aliasArray = [
        (f"{i}_normed", f"{i} / bin_center_0**2", j) 
           for i in ["mean", "std", "quantile_0", "quantile_1", "quantile_2"]
           for j in ["histoAB_1", "histoABWeight_1", "projectionA", "projectionAWeight"]
    ] 
```