### PR TITLE
Y-Axis transforms (#254, #247)

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.py
@@ -1,0 +1,9 @@
+from bokeh.model import Model
+from bokeh.core.properties import String, List
+
+# Simple wrapper for javascript String.prototype.concat
+
+class ConcatenatedString(Model):
+    __implementation__ = "ConcatenatedString.ts"
+
+    components = List(String)

--- a/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.ts
@@ -1,0 +1,48 @@
+import {Model} from "model"
+import * as p from "core/properties"
+
+export namespace ConcatenatedString {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    components: p.Property<string[]>
+  }
+}
+
+export interface ConcatenatedString extends ConcatenatedString.Attrs {}
+
+export class ConcatenatedString extends Model {
+  properties: ConcatenatedString.Props
+
+  constructor(attrs?: Partial<ConcatenatedString.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "ConcatenatedString"
+
+  #is_dirty: boolean
+  #value: string
+
+  static init_ConcatenatedString() {
+    this.define<ConcatenatedString.Props>(({Array, String})=>({
+      components:  [Array(String), []]
+    }))
+  }
+
+  initialize(){
+    super.initialize()
+    this.#is_dirty = false
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+  }
+
+  compute(): string{
+    if (this.#is_dirty){
+        this.#value = String.prototype.concat(this.components)
+    }
+    return this.#value
+  }
+
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ConcatenatedString.ts
@@ -36,13 +36,18 @@ export class ConcatenatedString extends Model {
 
   connect_signals(): void {
     super.connect_signals()
+    this.connect(this.properties.components.change, () => {this.#is_dirty = true})
   }
 
   compute(): string{
     if (this.#is_dirty){
-        this.#value = String.prototype.concat(this.components)
+        this.#value = String.prototype.concat(...this.components)
     }
     return this.#value
+  }
+
+  get value(){
+    return this.compute()
   }
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/CustomJSNAryFunction.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CustomJSNAryFunction.ts
@@ -51,7 +51,8 @@ export class CustomJSNAryFunction extends Model {
   update_func(){
     this.args_keys = Object.keys(this.parameters)
     this.args_values = Object.values(this.parameters)
-      this.scalar_func = new Function(...this.args_keys, ...this.fields, '"use strict";\n'+this.func)
+    this.scalar_func = new Function(...this.args_keys, ...this.fields, '"use strict";\n'+this.func)
+    this.change.emit()
   }
 
   compute(x: any[]){
@@ -61,7 +62,8 @@ export class CustomJSNAryFunction extends Model {
   update_vfunc(){
     this.args_keys = Object.keys(this.parameters)
     this.args_values = Object.values(this.parameters)
-    this.vector_func = new Function(...this.args_keys, ...this.fields, '"use strict";\n'+this.v_func)
+    this.vector_func = new Function(...this.args_keys, ...this.fields, "$output",'"use strict";\n'+this.v_func)
+    this.change.emit()
   }
 
   update_args(){

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -425,6 +425,12 @@ export class HistoNdProfile extends ColumnarDataSource {
           }
         }
         this._stale = false
+        if(sorted_weights != null){
+          source.return_column_to_pool(sorted_weights)
+        }
+        if(sorted_entries != null){
+          source.return_column_to_pool(sorted_entries)
+        }
   }
 
   get_column(key: string){

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1853,7 +1853,9 @@ def makeAxisLabelFromTemplate(template:str, paramDict:dict, meta: dict):
     for i in range(1, len(components), 2):
         if components[i] in paramDict:
             if "options" in paramDict[components[i]]:
-                options = {j:meta.get(f"{j}.AxisTitle", j) for j in paramDict[components[i]]["options"]}
+                options = {str(j):meta.get(f"{j}.AxisTitle", str(j)) for j in paramDict[components[i]]["options"]}
+                if 'None' in options:
+                    options["None"] = ''
                 paramDict[components[i]]["subscribed_events"].append(["change", CustomJS(args={"i":i, "label":label, "options":options}, code="""
                     label.components[i] = options[this.value];
                     label.properties.components.change.emit();
@@ -1866,7 +1868,8 @@ def makeAxisLabelFromTemplate(template:str, paramDict:dict, meta: dict):
                     label.change.emit();
                 """)])
             components[i] = paramDict[components[i]]["value"]
-        components[i] = meta.get(components[i]+".AxisTitle", components[i])
+        components[i] = str(components[i]) if components[i] is not None else ''
+        components[i] = meta.get(f"{components[i]}.AxisTitle", components[i])
     label.components = components
     return label
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1853,7 +1853,7 @@ def makeAxisLabelFromTemplate(template:str, paramDict:dict, meta: dict):
     for i in range(1, len(components), 2):
         if components[i] in paramDict:
             if "options" in paramDict[components[i]]:
-                options = {j:meta.get(j+".AxisTitle", j) for j in paramDict[components[i]]["options"]}
+                options = {j:meta.get(f"{j}.AxisTitle", j) for j in paramDict[components[i]]["options"]}
                 paramDict[components[i]]["subscribed_events"].append(["change", CustomJS(args={"i":i, "label":label, "options":options}, code="""
                     label.components[i] = options[this.value];
                     label.properties.components.change.emit();

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1497,19 +1497,6 @@ def defaultNDProfileTooltips(varNames, axis_idx, quantiles, sumRanges):
         tooltips.append((f"Sum_normed {varNames[axis_idx]} in [{iRange[0]}, {iRange[1]}]", "@sum_normed_" + str(i)))
     return tooltips
 
-def getOrMakeColumn(dfQuery, column, cdsName, ignoreDict={}):
-    if '.' in column:
-        c = column.split('.')
-        if cdsName is None or cdsName == c[0]:
-            return [dfQuery, c[1], c[0]]
-        else:
-            raise ValueError("Inconsistent CDS")
-    else:
-        if column in ignoreDict:
-            return [dfQuery, column, cdsName]
-        dfQuery, column = pandaGetOrMakeColumn(dfQuery, column)
-        return [dfQuery, column, None]
-
 def getTooltipColumns(tooltips):
     if isinstance(tooltips, str):
         return {}

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -870,7 +870,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     """)
                     js_transforms[func_option] = option_customjs
                     parsed_options[func_option] = option_parsed
-                    y_transform_parameters = y_transform_parameters | option_parameters
+                    y_transform_parameters.update(option_parameters)
                 y_transform_parsed["options"] = parsed_options
                 y_transform_customjs.args["options"] = js_transforms
                 paramDict[y_transform_parsed["name"]]["subscribed_events"].append(["value", CustomJS(args={"mapper":y_transform_customjs}, code="""
@@ -1386,7 +1386,7 @@ def makeSliderParameters(df: pd.DataFrame, params: list, **kwargs):
         pass
     if options['type'] == 'user':
         start, end, step = params[1], params[2], params[3]
-    elif (options['type'] == 'auto') | (options['type'] == 'minmax'):
+    elif (options['type'] == 'auto') or (options['type'] == 'minmax'):
         start = np.nanmin(df[name])
         end = np.nanmax(df[name])
         step = (end - start) / options['bins']
@@ -1626,7 +1626,8 @@ def errorBarWidthAsymmetric(varError: tuple, varX: dict, data_source, transform=
             mapper_upper.change.emit()
         """)])
     else:
-        args = transform["parameters"] | {"source":data_source, "key":varNameX}
+        args = transform["parameters"].copy()
+        args.update({"source":data_source, "key":varNameX})
         transform_lower = CustomJSTransform(args=args, v_func=f"""
             const column = [...source.get_column(key)]
             return column.map((x, i) => {transform["implementation"]}(x-xs[i]))

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1049,6 +1049,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     if optionLocal["legend_field"] is None:
                         x_label = getHistogramAxisTitle(cdsDict, varNameX, cds_name)
                         y_label = getHistogramAxisTitle(cdsDict, varNameY, cds_name)
+                        if y_transform:
+                            y_label = f"{{{y_transform}}} {y_label}"
                         legend_label = makeAxisLabelFromTemplate(f"{y_label} vs {x_label}", paramDict, meta)
                         if isinstance(legend_label, str):
                             drawnGlyph = figureI.scatter(x=varNameX, y=dataSpecY, fill_alpha=1, source=cds_used, size=markerSize,

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1429,8 +1429,7 @@ def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, defau
             dfCategorical = df[params[0]]
         codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
         optionsPlot = optionsPlot.dropna().to_list()
-    for i, val in enumerate(optionsPlot):
-        optionsPlot[i] = str((val))
+    optionsPlot = [str(i) for i in optionsPlot]
     default_value = 0
     if isinstance(default, int):
         if 0 <= default < len(optionsPlot):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1030,9 +1030,11 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     right = variables_dict["X"][1]["name"]
                     bottom = variables_dict["Y"][0]["name"]
                     top = variables_dict["Y"][1]["name"]
+                    dataSpecBottom = {"field":bottom, "transform":y_transform_customjs} if y_transform else bottom
+                    dataSpecTop = {"field":top, "transform":y_transform_customjs} if y_transform else top
                     x_label = getHistogramAxisTitle(cdsDict, left, cds_name)
                     y_label = getHistogramAxisTitle(cdsDict, bottom, cds_name)
-                    drawnGlyph = figureI.quad(top=top, bottom=bottom, left=left, right=right,
+                    drawnGlyph = figureI.quad(top=dataSpecTop, bottom=dataSpecBottom, left=left, right=right,
                     fill_alpha=1, source=cds_used, color=color, legend_label=y_label + " vs " + x_label)
                 elif visualization_type == "scatter":
                     varNameX = variables_dict["X"]["name"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -545,7 +545,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     transform = CustomJSNAryFunction(parameters=customJsArgList, fields=i["variables"], func=i["func"])
             if "expr" in i:
                 exprTree = ast.parse(i["expr"], filename="<unknown>", mode="eval")
-                evaluator = ColumnEvaluator(i.get("context", None), cdsDict, paramDict, {}, i["expr"], aliasDict)
+                evaluator = ColumnEvaluator(i.get("context", None), cdsDict, paramDict, jsFunctionDict, i["expr"], aliasDict)
                 result = evaluator.visit(exprTree.body)
                 if result["type"] == "javascript":
                     func = "return "+result["implementation"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1866,11 +1866,19 @@ def makeAxisLabelFromTemplate(template:str, paramDict:dict, meta: dict):
     label = ConcatenatedString()
     for i in range(1, len(components), 2):
         if components[i] in paramDict:
-            paramDict[components[i]]["subscribed_events"].append(["change", CustomJS(args={"i":i, "label":label}, code="""
-                label.components[i] = this.value;
-                label.properties.components.change.emit()
-                label.change.emit();
-            """)])
+            if "options" in paramDict[components[i]]:
+                options = {j:meta.get(j+".AxisTitle", j) for j in paramDict[components[i]]["options"]}
+                paramDict[components[i]]["subscribed_events"].append(["change", CustomJS(args={"i":i, "label":label, "options":options}, code="""
+                    label.components[i] = options[this.value];
+                    label.properties.components.change.emit();
+                    label.change.emit();
+                """)])
+            else:
+                paramDict[components[i]]["subscribed_events"].append(["change", CustomJS(args={"i":i, "label":label}, code="""
+                    label.components[i] = this.value;
+                    label.properties.components.change.emit();
+                    label.change.emit();
+                """)])
             components[i] = paramDict[components[i]]["value"]
         components[i] = meta.get(components[i]+".AxisTitle", components[i])
     label.components = components

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -456,9 +456,6 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         "flip_histogram_axes": False,
         "show_histogram_error": False,
         "arrayCompression": None,
-        "xAxisTitle": None,
-        "yAxisTitle": None,
-        "plotTitle": None,
         "removeExtraColumns": False
     }
     options.update(kwargs)
@@ -1119,26 +1116,31 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
 
         xAxisTitle = ", ".join(xAxisTitleBuilder)
         yAxisTitle = ", ".join(yAxisTitleBuilder)
-
-        if optionLocal["xAxisTitle"] is not None:
-            xAxisTitle = optionLocal["xAxisTitle"]
-        if optionLocal["yAxisTitle"] is not None:
-            yAxisTitle = optionLocal["yAxisTitle"]
         plotTitle = yAxisTitle + " vs " + xAxisTitle
-        if optionLocal["plotTitle"] is not None:
-            plotTitle = optionLocal["plotTitle"]
 
+        xAxisTitle = optionLocal.get("xAxisTitle", xAxisTitle)
+        yAxisTitle = optionLocal.get("yAxisTitle", yAxisTitle)
+        plotTitle = optionLocal.get("plotTitle", plotTitle)
+
+        xAxisTitleModel = makeAxisLabelFromTemplate(xAxisTitle, paramDict, meta)
+        yAxisTitleModel = makeAxisLabelFromTemplate(yAxisTitle, paramDict, meta)
         plotTitleModel = makeAxisLabelFromTemplate(plotTitle, paramDict, meta)
 
-        figureI.title.text = plotTitle
         if isinstance(plotTitleModel, ConcatenatedString):
             plotTitleModel.js_on_change("change", CustomJS(args={"target":figureI.title}, code="target.text = this.value"))
             figureI.title.text = ''.join(plotTitleModel.components)
         else:
             figureI.title.text = plotTitleModel
-
-        figureI.xaxis.axis_label = xAxisTitle
-        figureI.yaxis.axis_label = yAxisTitle
+        if isinstance(xAxisTitleModel, ConcatenatedString):
+            xAxisTitleModel.js_on_change("change", CustomJS(args={"target":figureI.xaxis[0]}, code="target.axis_label = this.value"))
+            figureI.xaxis.axis_label = ''.join(xAxisTitleModel.components)
+        else:
+            figureI.xaxis.axis_label = xAxisTitleModel
+        if isinstance(yAxisTitleModel, ConcatenatedString):
+            yAxisTitleModel.js_on_change("change", CustomJS(args={"target":figureI.yaxis[0]}, code="target.axis_label = this.value"))
+            figureI.yaxis.axis_label = ''.join(yAxisTitleModel.components)
+        else:
+            figureI.yaxis.axis_label = yAxisTitleModel
 
         if color_bar is not None:
             figureI.add_layout(color_bar, 'right')

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1214,8 +1214,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     paramDict[value["name"]]["subscribed_events"].append(["value", CustomJS(args={"cdsAlias": cdsDict[cdsKey]["cdsFull"], "key": columnKey},
                                                                                             code="""
                                                                                                 cdsAlias.mapping[key] = this.value;
-                                                                                                cdsAlias.compute_function(key);
-                                                                                                cdsAlias.change.emit();
+                                                                                                cdsAlias.invalidate_column(key);
                                                                                             """)])
 
     for iCds, widgets in widgetDict.items():

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1847,7 +1847,7 @@ def makeCDSDict(sourceArray, paramDict):
             raise NotImplementedError("Unrecognized CDS type: " + cdsType)
     return cdsDict
 
-def makeAxisLabelFromTemplate(template:str, paramDict:dict):
+def makeAxisLabelFromTemplate(template:str, paramDict:dict, meta: dict):
     components = re.split(r"\{(\w+)\}", template)
     if len(components) == 1:
         return components[0]
@@ -1859,5 +1859,7 @@ def makeAxisLabelFromTemplate(template:str, paramDict:dict):
                 label.components[i] = this.value;
                 label.change.emit();
             """)])
+        if components[i] in meta:
+            components[i] = meta[components[i]].get("AxisTitle", components[i])
     label.components = components
     return label

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -203,7 +203,7 @@ class ColumnEvaluator:
         if node.id in JAVASCRIPT_GLOBALS:
             return {
                 "name": node.id,
-                "implementation": node.id,
+                "implementation": JAVASCRIPT_GLOBALS[node.id],
                 "type": "js_lambda"
             }
         if node.id in self.funcDict:

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -58,6 +58,8 @@ class ColumnEvaluator:
         self.code = code
         self.isSource = True 
         self.aliasDict = aliasDict
+        self.isAuto = False
+        self.locals = []
 
     def visit(self, node):
         if isinstance(node, ast.Attribute):
@@ -78,38 +80,27 @@ class ColumnEvaluator:
             return self.visit_BoolOp(node)
         elif isinstance(node, ast.IfExp):
             return self.visit_IfExp(node)
+        elif isinstance(node, ast.Lambda):
+            return self.visit_Lambda(node)
         else:
             return self.eval_fallback(node)
 
     def visit_Call(self, node: ast.Call):
-        # This is never used in bokehDrawArray but there's still a unit test for it, and the dependency tree is generated correctly even in this case
-        if not isinstance(node.func, ast.Name):
-            raise ValueError("Functions in variables list can only be specified by names")
-        if node.func.id in self.funcDict:
-            args = []
-            for iArg in node.args:
-                args.append(self.visit(iArg))
-            return {
-                "value": {
-                    "func": node.func.id,
-                    "args": args
-                },
-                "type": "client_function",
-                "name": self.code
-            }
-        if node.func.id in JAVASCRIPT_GLOBALS:
-            args = []
-            implementation = JAVASCRIPT_GLOBALS[node.func.id] + '('
-            for iArg in node.args:
-                args.append(self.visit(iArg))
-                implementation += args[-1]["implementation"]
-            implementation += ')'
-            return {
-                "implementation": implementation,
-                "type": "javascript",
-                "name": self.code
-            }
-        return self.eval_fallback(node)
+        left = self.visit(node.func)
+        if left["type"] == "parameter":
+            # TODO: Make a parameter unswitcher - should help improve performance - but same can also apply to other scalars?
+            pass
+        args = []
+        implementation = JAVASCRIPT_GLOBALS[node.func.id] + '('
+        for iArg in node.args:
+            args.append(self.visit(iArg))
+            implementation += args[-1]["implementation"]
+        implementation += ')'
+        return {
+            "implementation": implementation,
+            "type": "javascript",
+            "name": self.code
+        }
 
     def visit_Num(self, node: ast.Num):
         # Kept for compatibility with old Python
@@ -123,17 +114,15 @@ class ColumnEvaluator:
     def visit_Attribute(self, node: ast.Attribute):
         if self.context in self.aliasDict and node.attr in self.aliasDict[self.context]:
             # We have an alias in aliasDict
-            self.isSource = self.isSource and \
-                            isinstance(self.aliasDict[self.context][node.attr], str) and \
-                            self.aliasDict[self.context][node.attr] == node.attr
-            if isinstance(self.aliasDict[self.context][node.attr], str):
-                self.dependencies.add((self.context, self.aliasDict[self.context][node.attr]))
+            self.isSource = False
+            if "expr" in self.aliasDict[self.context][node.attr]:
+                self.dependencies.add((self.context, self.aliasDict[self.context][node.attr]["expr"]))
                 return {
                     "name": node.attr,
                     "implementation": node.attr,
                     "type": "alias"
                 }
-            if "fields" in self.aliasDict[self.context][node.attr]:
+            elif "fields" in self.aliasDict[self.context][node.attr]:
                 for i in self.aliasDict[self.context][node.attr]["fields"]:
                     self.dependencies.add((self.context, i))
             self.aliasDependencies.add(node.attr)
@@ -203,12 +192,34 @@ class ColumnEvaluator:
 
     def visit_Name(self, node: ast.Name):
         # There are two cases, either we are selecting the namespace or the column from the current one
+        if node.id == "auto":
+            self.isSource = False
+            self.isAuto = True
+            return {
+                "name": node.id,
+                "implementation": node.id,
+                "type": "auto"
+            }
+        if node.id in JAVASCRIPT_GLOBALS:
+            return {
+                "name": node.id,
+                "implementation": node.id,
+                "type": "js_lambda"
+            }
+        if node.id in self.funcDict:
+            self.isSource = False
+            return {
+                "name": node.id,
+                "implementation": node.id,
+                "type": "js_lambda"
+            }
         if node.id in self.paramDict:
             self.isSource = False
             if "options" in self.paramDict[node.id]:
                 for iOption in self.paramDict[node.id]["options"]:
                     self.dependencies.add((self.context, iOption))
             self.paramDependencies.add(node.id)
+            # Detect if parameter is a lambda here?
             return {
                 "name": node.id,
                 "implementation": node.id,
@@ -382,6 +393,16 @@ class ColumnEvaluator:
             "name": self.code,
             "type": "javascript",
             "implementation": implementation
+        }
+
+    def visit_Lambda(self, node:ast.Lambda):
+        args = node.args
+        impl_args = ', '.join([self.visit(i)["implementation"] for i in args])
+        impl_body = self.visit(node.body)["implementation"]
+        return {
+            "name": self.code,
+            "type": "js_lambda",
+            "implementation": f"(({impl_args})=>({impl_body}))"
         }
 
 def checkColumn(columnKey, tableKey, cdsDict):

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -200,6 +200,12 @@ class ColumnEvaluator:
                 "implementation": node.id,
                 "type": "auto"
             }
+        if self.locals and node.id in self.locals[-1]:
+            return {
+                "name": node.id,
+                "implementation": node.id,
+                "type": "auto"
+            }            
         if node.id in JAVASCRIPT_GLOBALS:
             return {
                 "name": node.id,
@@ -396,9 +402,14 @@ class ColumnEvaluator:
         }
 
     def visit_Lambda(self, node:ast.Lambda):
-        args = node.args
-        impl_args = ', '.join([self.visit(i)["implementation"] for i in args])
+        args = [i.arg for i in node.args.args]
+        impl_args = ', '.join([i.arg for i in node.args.args])
+        if self.locals:
+            self.locals.append(self.locals[-1] | set(args))
+        else:
+            self.locals.append(set(args))
         impl_body = self.visit(node.body)["implementation"]
+        self.locals.pop()
         return {
             "name": self.code,
             "type": "js_lambda",

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -71,7 +71,8 @@ def testBokehClientHistogram():
         [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2",
                                                             "rescaleColorMapper": True, "size":"size"}],
         [['B'], ['histoB', '(C+B)*10', '(C-B)*10'], {"size": 7, "colorZvar": "C", "errY": "errY",
-                                                    "rescaleColorMapper": True, "size":"size"}]
+                                                    "rescaleColorMapper": True, "size":"size"}],
+        {"y_transform":"transformY"}
     ]
     xxx=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=300, histogramArray=histoArray)
@@ -382,5 +383,3 @@ def test_StableQuantile():
     
     xxx=bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
-
-testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -80,7 +80,7 @@ def testBokehClientHistogram():
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
     figureArray = [
-        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")]}],
+        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "yAxisTitle":"{transformY}(N)"}],
         [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "log(bin_count+1)", "source":"histoAB"}],
         [['bin_count'], ['bin_center'], {"source": "histoB"}],
@@ -384,3 +384,5 @@ def test_StableQuantile():
     
     xxx=bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
+
+testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -1,12 +1,8 @@
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
 from RootInteractive.Tools.aliTreePlayer import *
-from bokeh.io import curdoc
 from pandas import CategoricalDtype
 
-output_file("test_bokehClientHistogram.html")
-# import logging
-
-df = pd.DataFrame(np.random.random_sample(size=(20000, 4)), columns=list('ABCD'))
+df = pd.DataFrame(np.random.random_sample(size=(2000, 4)), columns=list('ABCD'))
 initMetadata(df)
 MARKERS = ['hex', 'circle_x', 'triangle','square']
 markerFactor=factor_mark('DDC', MARKERS, ["A0","A1","A2","A3","A4"] )
@@ -32,7 +28,8 @@ tooltips = [("VarA", "(@A)"), ("VarB", "(@B)"), ("VarC", "(@C)"), ("VarD", "(@D)
 parameterArray=[
     {'name':"size", "value":7, "range": [0, 20]},
     {'name':"histoRangeA", "value": [0, 1], "range": [0, 1]},
-    {'name':"nBinsB", "value": 20, "options":[5, 10, 20, 40]}
+    {'name':"nBinsB", "value": 20, "options":[5, 10, 20, 40]},
+    {'name':"transformY", "value":None, "options":[None, "sqrt", "lambda x: log(x+1)"]}
 ]
 
 widgetParams=[
@@ -43,11 +40,12 @@ widgetParams=[
     ['multiSelect', ["DDC"]],
     ['slider',["size"]],
     ['range', ['histoRangeA']],
-    ['select', ['nBinsB']]
+    ['select', ['nBinsB']],
+    ['select', ['transformY']]
   #  ['select',["CC", 0, 1, 2, 3]],
   #  ['multiSelect',["BoolB"]],
 ]
-widgetLayoutDesc=[[0, 1, 2], [3, 4], [5], [6, 7], {'sizing_mode': 'scale_width'}]
+widgetLayoutDesc=[[0, 1, 2], [3, 4], [5, 6], [7, 8], {'sizing_mode': 'scale_width'}]
 
 figureLayoutDesc=[
     [0, 1, 2, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 300}],
@@ -81,8 +79,8 @@ def testBokehClientHistogram():
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
     figureArray = [
-        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")]}],
-        [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB"}],
+        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "y_transform":"transformY"}],
+        [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB", "y_transform":"transformY"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "log(bin_count+1)", "source":"histoAB"}],
         [['bin_count'], ['bin_center'], {"source": "histoB"}],
         ["tableHisto", {"rowwise": False, "include": "histoA$|histoB$"}],
@@ -380,3 +378,5 @@ def test_StableQuantile():
     
     xxx=bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
+
+testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -89,6 +89,7 @@ def testBokehClientHistogramOnlyHisto():
         [['bin_center_0'], ['cumulative'], {"source": "histoAB_1"}],
         [['bin_center'], ['cdf'], {"source": "histoA"}],
         [['bin_center_0'], ['cdf'], {"source": "histoAB_1"}],
+        {"y_transform":"transformY"}
     ]
     figureLayoutDesc={
             "Histograms":[

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -79,15 +79,15 @@ def testBokehClientHistogram():
 def testBokehClientHistogramOnlyHisto():
     output_file("test_BokehClientHistogramOnlyHisto.html")
     figureArray = [
-        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "y_transform":"transformY"}],
-        [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB", "y_transform":"transformY"}],
+        [['bin_center'], ['bin_count'], {"source": "histoA", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")]}],
+        [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "log(bin_count+1)", "source":"histoAB"}],
         [['bin_count'], ['bin_center'], {"source": "histoB"}],
         ["tableHisto", {"rowwise": False, "include": "histoA$|histoB$"}],
         [['bin_center'], ['cumulative'], {"source": "histoA"}],
         [['bin_center_0'], ['cumulative'], {"source": "histoAB_1"}],
         [['bin_center'], ['cdf'], {"source": "histoA"}],
-        [['bin_center_0'], ['cdf'], {"source": "histoAB_1"}]
+        [['bin_center_0'], ['cdf'], {"source": "histoAB_1"}],
     ]
     figureLayoutDesc={
             "Histograms":[

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -384,5 +384,3 @@ def test_StableQuantile():
     
     xxx=bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                               widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=3000, histogramArray=histoArray, aliasArray=aliasArray)
-
-testBokehClientHistogramOnlyHisto()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -113,7 +113,8 @@ def testBokehClientHistogramProfileA():
         [['bin_center_0'], ['quantile_1', 'mean'], {"size":"size", "source":"histoAB_1"}],
         [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2", "size":"size"}],
         [['bin_center_0'], ['std'], {"size":"size", "source":"histoAB_1"}],
-        ["tableHisto", {"rowwise": False}]
+        ["tableHisto", {"rowwise": False}],
+        {"y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -131,7 +132,8 @@ def testBokehClientHistogramProfileB():
         [['bin_center_1'], ['quantile_1', 'mean'], {"size":"size", "source":"histoAB_0"}],
         [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2"}],
         [['bin_center_1'], ['std'], {"size":"size", "source":"histoAB_0"}],
-        ["tableHisto", {"rowwise": False}]
+        ["tableHisto", {"rowwise": False}],
+        {"y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -150,7 +152,8 @@ def testBokehClientHistogramRowwiseTable():
         [['A'], ['histoAB'], {"visualization_type": "colZ", "show_histogram_error": True}],
         [['A'], ['histoAB'], {"yAxisTitle": "(A+B)/2"}],
         [['B'], ['histoB'], {"flip_histogram_axes": True}],
-        ["tableHisto", {"rowwise": True, "exclude": r".*_.*"}]
+        ["tableHisto", {"rowwise": True, "exclude": r".*_.*"}],
+        {"y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -170,7 +173,8 @@ def testBokehClientHistogram3d():
         [['histoABC_0.bin_center_1'], ['histoABC_0.mean'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
-        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}]
+        [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2", "size": "size"}],
+        {"y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -192,7 +196,7 @@ def testBokehClientHistogram3d_colormap():
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2" }],
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2" }],
         [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2" }],
-        {"size": "size", "rescaleColorMapper": True}
+        {"size": "size", "rescaleColorMapper": True, "y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -215,7 +219,7 @@ def testBokehClientHistogram3d_colormap_noscale():
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_0'], {"colorZvar": "histoABC_0.bin_center_2"}],
         [['histoABC_0.bin_center_1'], ['histoABC_0.sum_normed_0'], {"colorZvar": "histoABC_0.bin_center_2"}],
         [['histoABC_0.bin_center_1'], ['histoABC_0.std'], {"colorZvar": "histoABC_0.bin_center_2"}],
-        {"size": "size"}
+        {"size": "size", "y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
@@ -258,7 +262,7 @@ def testJoin():
         [['histoAB_0.bin_center_1', 'histoB.bin_center'], ['histoAB_0.entries', 'histoB.bin_count']],
         [['histoB_join_histoAB_0.bin_center_1'], ['histoB_join_histoAB_0.delta_mean']],
         [['histoAB_0.bin_center_1'], ['histoAB_0.std']],
-        {"size": "size"}
+        {"size": "size", "y_transform":"transformY"}
     ]
     figureLayoutDesc=[
         [0, 1, {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -67,7 +67,7 @@ figureArray = [
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
     [['D'], ['D*10'], {"size": 10, "errY": "errY"}],
-    {"size":"size", "y_transform":"exp", "legend_options": {"label_text_font_size": "legendFontSize", "visible": "legendVisible"}}
+    {"size":"size", "y_transform":"lambda x: x+size", "legend_options": {"label_text_font_size": "legendFontSize", "visible": "legendVisible"}}
 ]
 
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"
@@ -142,3 +142,6 @@ def testBokehDrawArrayQuery(record_property: ty.Callable[[str, ty.Any], None]):
     record_property("html_size",os.stat("test_BokehDrawArrayWidget.html").st_size)
     record_property("cdsOrig_size",len(fig.cdsOrig.column_names))
     assert (df0.keys() == df.keys()).all()
+
+output_file("test_BokehDrawArrayWidget.html")
+fig=bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", parameterArray=parameterArray, nPointRender="nPoints")

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -67,7 +67,7 @@ figureArray = [
 #    [['D'], ['D*10'], {"size": 10, "errY": "errY","markers":markerFactor, "color":colorFactor,"legend_field":"DDC"}],
     #marker color works only once - should be constructed in wrapper
     [['D'], ['D*10'], {"size": 10, "errY": "errY"}],
-    {"size":"size", "legend_options": {"label_text_font_size": "legendFontSize", "visible": "legendVisible"}}
+    {"size":"size", "y_transform":"exp", "legend_options": {"label_text_font_size": "legendFontSize", "visible": "legendVisible"}}
 ]
 
 widgets="slider.A(0,1,0.05,0,1), slider.B(0,1,0.05,0,1), slider.C(0,1,0.01,0.1,1), slider.D(0,1,0.01,0,1), checkbox.Bool(1)"


### PR DESCRIPTION
Because of bokeh technical limitations, changing axis scales is not possible without making large changes. However, if changing the tickers and inverting the transform isn't needed, this PR adds a workaround.

This PR:
- Adds a parameter for bokehDrawArray in figureArray - "y_transform" - takes the transformation applied to it Can be either None for the identity transform, a parameter in parameterArray or a string which is interpreted as an expression to use.
- Optimizes bin caching for ND histograms by adding array pooling

Example:
```python
parameterArray=[
    {'name':"transformY", "value":None, "options":[None, "sqrt", "lambda x: log(x+1)"]}
]
figureArray=[
[['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": "sqrt(bin_count)", "source":"histoAB", "y_transform":"transformY"}]
]
```
- Adds support for string formatting to axis labels and plot label - use curly braces to denote variable name with metadata added or parameter - when testing, regression was noticed - regression was caused by updating to bokeh 2.4 from 2.2, it's a known bug in Bokeh - https://github.com/bokeh/bokeh/issues/11116 - considering writing a workaround
