### PR TITLE
Cumulative histogram

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -191,7 +191,6 @@ export class CDSAlias extends ColumnarDataSource {
       } else if(Object.prototype.toString.call(column) === '[object String]'){
         if(key === column){
           should_invalidate = true
-          break
         }
       }
       if(should_invalidate){

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -175,6 +175,7 @@ export class HistoNdProfile extends ColumnarDataSource {
         let std_column = []
         let entries_column = []
         let isOK_column = []
+        let cumulative_column = []
         let quantile_columns:Array<Array<number>> = []
         for (let i = 0; i < quantiles.length; i++) {
           quantile_columns.push([])
@@ -228,6 +229,8 @@ export class HistoNdProfile extends ColumnarDataSource {
 
         const nbins_total = source.length
 
+        let entries_total = 0
+
         for(let x = 0; x < nbins_total; x += stride_high){
           for(let z = 0; z < stride_low; z ++){
       //      console.log(x)
@@ -244,6 +247,7 @@ export class HistoNdProfile extends ColumnarDataSource {
               std_column.push(NaN)
               entries_column.push(NaN)
               isOK_column.push(false)
+              cumulative_column.push(null)
               continue
             }
             let cumulative_histogram = []
@@ -252,6 +256,8 @@ export class HistoNdProfile extends ColumnarDataSource {
               entries += bin_count[x+y+z]
               cumulative_histogram.push(entries)
             }
+            cumulative_column.push(entries_total + entries/2)
+            entries_total += entries
             if(entries > 0){
               let mean = 0
               if(unbinned){
@@ -402,6 +408,8 @@ export class HistoNdProfile extends ColumnarDataSource {
         this.data["std"] = std_column
         this.data["entries"] = entries_column
         this.data["isOK"] = isOK_column
+        this.data["cumulative"] = cumulative_column
+        this.data["cdf"] = cumulative_column.map((x) => x / entries_total)
         for (let iQuantile = 0; iQuantile < quantile_columns.length; iQuantile++) {
           this.data["quantile_"+iQuantile] = quantile_columns[iQuantile]
         }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -175,7 +175,7 @@ export class HistoNdProfile extends ColumnarDataSource {
         let std_column = []
         let entries_column = []
         let isOK_column = []
-        let cumulative_column = []
+        let cumulative_column: number[] = []
         let quantile_columns:Array<Array<number>> = []
         for (let i = 0; i < quantiles.length; i++) {
           quantile_columns.push([])
@@ -247,7 +247,7 @@ export class HistoNdProfile extends ColumnarDataSource {
               std_column.push(NaN)
               entries_column.push(NaN)
               isOK_column.push(false)
-              cumulative_column.push(null)
+              cumulative_column.push(NaN)
               continue
             }
             let cumulative_histogram = []

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -545,7 +545,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     transform = CustomJSNAryFunction(parameters=customJsArgList, fields=i["variables"], func=i["func"])
             if "expr" in i:
                 exprTree = ast.parse(i["expr"], filename="<unknown>", mode="eval")
-                evaluator = ColumnEvaluator(i.get("context", None), cdsDict, paramDict, None, i["expr"], aliasDict)
+                evaluator = ColumnEvaluator(i.get("context", None), cdsDict, paramDict, {}, i["expr"], aliasDict)
                 result = evaluator.visit(exprTree.body)
                 if result["type"] == "javascript":
                     func = "return "+result["implementation"]

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -55,7 +55,11 @@ figureLayoutDesc=[
 ]
 
 histoArray = [
-    {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]]},
+    {"name": "histoA", "variables": ["A"], "nbins":20, "range": "histoRangeA", "quantiles": [.05, .5, .95], "sum_range": [[.25, .75], [.4, .6]],
+         "histograms": {
+            "cumulative": {"cumulative":True},
+            "cdf": {"cumulative":True, "density":True}
+         }},
     {"name": "histoB", "variables": ["B"], "nbins":"nBinsB", "range": [0, 1]},
     {"name": "histoABC", "variables": ["A", "B", "C"], "nbins":[10, "nBinsB", 10], "range": ["histoRangeA", None, None], "quantiles": [.5], "sumRange": [[.25, .75]], "axis": [0, 2]},
     {"name": "histoAB", "variables": ["A", "(A+B)/2"], "nbins": [20, "nBinsB"], "range": ["histoRangeA", None], "unbinned_projections":True, "weights": "D", "quantiles": [.25, .5, .75], "axis": [0, 1]},
@@ -81,14 +85,26 @@ def testBokehClientHistogramOnlyHisto():
         [['bin_center_0'], ['bin_count'], {"colorZvar":"bin_center_1", "errY": [("sqrt(bin_count)", "sqrt(bin_count+1)")], "source":"histoAB"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "log(bin_count+1)", "source":"histoAB"}],
         [['bin_count'], ['bin_center'], {"source": "histoB"}],
-        ["tableHisto", {"rowwise": False, "include": "histoA$|histoB$"}]
+        ["tableHisto", {"rowwise": False, "include": "histoA$|histoB$"}],
+        [['bin_center'], ['cumulative'], {"source": "histoA"}],
+        [['bin_center_0'], ['cumulative'], {"source": "histoAB_1"}],
+        [['bin_center'], ['cdf'], {"source": "histoA"}],
+        [['bin_center_0'], ['cdf'], {"source": "histoAB_1"}]
     ]
-    figureLayoutDesc=[
-        [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
-        [2, 3, {'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
-        [4, {'plot_height': 40}],
-        {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
-    ]
+    figureLayoutDesc={
+            "Histograms":[
+                [0, 1,  {'commonX': 1, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+                [2, 3, {'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+                [4, {'plot_height': 40}],
+                {'plot_height': 100, 'sizing_mode': 'scale_width', 'y_visible' : 2, "size": 5}
+            ],
+            "Cumulative":[
+                [5,6, {'commonX': 5, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}],
+                [7,8, {'commonX': 5, 'y_visible': 1, 'x_visible':1, 'plot_height': 200}]
+            ]
+
+        }
+
     xxx = bokehDrawSA.fromArray(df, "A>0", figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                                 widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray)
 


### PR DESCRIPTION
This PR:
- Adds "cumulative" and "density" options to 1D histograms
-- Cumulative: take the inclusive cumulative histogram
-- Density: Divide by bin width and total (only total if taking cumulative histogram)
- Adds "cumulative" and "cdf" columns to projections
- Fixes a bug causing aliases to not work with javascript math functions - a quick workaround before the real fix can be applied in #256
