### PR TITLE
NaN handling in histograms, simplified compression insterface

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -113,13 +113,13 @@ export class CDSCompress extends ColumnDataSource {
     let arrayOut=arrayIn.array
     for(var i =  arrayIn.actionArray.length-1;i>=0; i--) {
       console.log((i + 1) + " --> " + arrayIn.actionArray[i])
-      if (arrayIn.actionArray[i][0] == "base64") {
-        //arrayOut=Buffer.from(arrayOut, 'base64');
+      const action = arrayIn.actionArray[i] instanceof String ? arrayIn.actionArray[i][0] : arrayIn.actionArray[i]
+      if (action == "base64"){
         arrayOut = atob(arrayOut).split("").map(function (x) {
           return x.charCodeAt(0)
-        });
+        })
       }
-      if (arrayIn.actionArray[i][0] == "zip") {
+      if (action == "zip") {
         //arrayOut=Buffer.from(arrayOut, 'base64');
         //var myArr = new Uint8Array(arrayOut)
         arrayOut = pako.inflate(arrayOut)
@@ -144,14 +144,14 @@ export class CDSCompress extends ColumnDataSource {
         }
         if (dtype == "float32"){
           arrayOut = new Float32Array(arrayOut.buffer)
-           arrayOut = new Float64Array(arrayOut)
+          arrayOut = new Float64Array(arrayOut)
         }
         if (dtype == "float64"){
           arrayOut = new Float64Array(arrayOut.buffer)
         }
         console.log(arrayOut)
       }
-      if (arrayIn.actionArray[i][0] == "code") {
+      if (action == "code") {
         if(arrayIn.skipCode){
           continue
         }

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -112,7 +112,7 @@ export class CDSCompress extends ColumnDataSource {
     let arrayOut=arrayIn.array
     for(var i =  arrayIn.actionArray.length-1;i>=0; i--) {
       console.log((i + 1) + " --> " + arrayIn.actionArray[i])
-      const action = arrayIn.actionArray[i] instanceof String ? arrayIn.actionArray[i][0] : arrayIn.actionArray[i]
+      const action = Object.prototype.toString.call(arrayIn.actionArray[i]) === '[object String]' ? arrayIn.actionArray[i] : arrayIn.actionArray[i][0]
       if (action == "base64"){
         arrayOut = atob(arrayOut).split("").map(function (x) {
           return x.charCodeAt(0)

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -105,7 +105,6 @@ export class CDSCompress extends ColumnDataSource {
 
   initialize(): void {
     super.initialize()
-    //this.data = {}
     console.info("CDSCompress::initialize")
     this.inflateCompressedBokehObjectBase64()
   }
@@ -120,8 +119,6 @@ export class CDSCompress extends ColumnDataSource {
         })
       }
       if (action == "zip") {
-        //arrayOut=Buffer.from(arrayOut, 'base64');
-        //var myArr = new Uint8Array(arrayOut)
         arrayOut = pako.inflate(arrayOut)
         const dtype = arrayIn.dtype
         if(arrayIn.byteorder !== BYTE_ORDER){
@@ -164,27 +161,16 @@ export class CDSCompress extends ColumnDataSource {
       }
     }
     return arrayOut
-    //arrayIn.actionArray.reverse().forEach(x => console.log(x))
   }
 
   inflateCompressedBokehObjectBase64() {
     this.data = {};
-    let objectOut0 = Object;
-    let objectOut = (objectOut0 as any);
     let objectIn = (this.inputData as any);
-    let length=0;
     for (let arr in objectIn) {
       let arrOut = this.inflateCompressedBokehBase64(objectIn[arr]);
       this.data[arr]=arrOut;
-      //if (arrOut.length!=length)
-      length=arrOut.length
       console.log(arr);
     }
-    this.data["index"]=new Uint32Array(length)
-     for (let i = 0; i < length; i++) {
-         this.data["index"][i]=i;
-        }
-    return objectOut
   }
 
 }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -385,8 +385,10 @@ export class HistoNdCDS extends ColumnarDataSource {
     let range_max = -Infinity
     const l = column.length
     for(let x=0; x<l; x++){
-      range_min = Math.min(range_min, column[x])
-      range_max = Math.max(range_max, column[x])
+      if(!isNaN(column[x])){
+        range_min = Math.min(range_min, column[x])
+        range_max = Math.max(range_max, column[x])
+      }
     }
     if(range_min == range_max){
       range_min -= 1

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -394,6 +394,10 @@ export class HistoNdCDS extends ColumnarDataSource {
       range_min -= 1
       range_max += 1
     }
+    if(!isFinite(range_min)){
+      range_min = 0
+      range_max = 1
+    }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    
     this._do_cache_bins = false
@@ -414,6 +418,10 @@ export class HistoNdCDS extends ColumnarDataSource {
     if(range_min == range_max){
       range_min -= 1
       range_max += 1
+    }
+    if(!isFinite(range_min)){
+      range_min = 0
+      range_max = 1
     }
     this._range_min[axis_idx] = range_min
     this._range_max[axis_idx] = range_max    

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -385,7 +385,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     let range_max = -Infinity
     const l = column.length
     for(let x=0; x<l; x++){
-      if(!isNaN(column[x])){
+      if(isFinite(column[x])){
         range_min = Math.min(range_min, column[x])
         range_max = Math.max(range_max, column[x])
       }
@@ -406,7 +406,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     const l = this.view!.length
     for(let x=0; x<l; x++){
       const y = view[x]
-      if(!isNaN(column[y])){
+      if(isFinite(column[y])){
         range_min = Math.min(range_min, column[y])
         range_max = Math.max(range_max, column[y])
       }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -404,8 +404,10 @@ export class HistoNdCDS extends ColumnarDataSource {
     const l = this.view!.length
     for(let x=0; x<l; x++){
       const y = view[x]
-      range_min = Math.min(range_min, column[y])
-      range_max = Math.max(range_max, column[y])
+      if(!isNaN(column[y])){
+        range_min = Math.min(range_min, column[y])
+        range_max = Math.max(range_max, column[y])
+      }
     }
     if(range_min == range_max){
       range_min -= 1

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -16,7 +16,7 @@ function kth_value(sample:any[], k:number, compare:(a:number, b:number)=>number,
     for(let i=begin; i<end; i++){
       pivot_idx += isNaN(sample[i]) || compare(sample[i], pivot) < 0 ? 1 : 0
     }
-    if(pivot_idx === end && isNaN(pivot)) return
+    if(pivot_idx >= end && isNaN(pivot)) return
     let pointer_mid = pivot_idx
     let pointer_high = end-1
     let pointer_low=begin
@@ -269,10 +269,12 @@ export class HistoNdProfile extends ColumnarDataSource {
                   const index_high = global_cumulative_histogram![x+y+z]
                   if(sorted_weights == null){
                     for(let i=index_low; i<index_high; ++i){
+                      if (isFinite(sorted_entries![i]))
                       mean += sorted_entries![i]
                     }
                   } else {
                     for(let i=index_low; i<index_high; ++i){
+                      if (isFinite(sorted_entries![i]))
                       mean += sorted_entries![i] * sorted_weights[i]
                     }
                   }
@@ -291,10 +293,12 @@ export class HistoNdProfile extends ColumnarDataSource {
                   const index_high = global_cumulative_histogram![x+y+z]
                   if(sorted_weights == null){
                     for(let i=index_low; i<index_high; ++i){
+                      if (isFinite(sorted_entries![i]))
                       std += sorted_entries![i] * sorted_entries![i]
                     }
                   } else {
                     for(let i=index_low; i<index_high; ++i){
+                      if (isFinite(sorted_entries![i]))
                       std += sorted_entries![i] * sorted_entries![i] * sorted_weights[i]
                     }
                   }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -82,8 +82,10 @@ export class HistogramCDS extends ColumnarDataSource {
           let range_max = -Infinity
           const l = sample_arr.length
           for(let x=0; x<l; x++){
-            range_min = Math.min(range_min, sample_arr[x])
-            range_max = Math.max(range_max, sample_arr[x])
+            if(!isNaN(sample_arr[x])){
+              range_min = Math.min(range_min, sample_arr[x])
+              range_max = Math.max(range_max, sample_arr[x])
+            }
           }
           if(range_min == range_max){
             range_min -= 1
@@ -107,8 +109,10 @@ export class HistogramCDS extends ColumnarDataSource {
           const l = this.view.length
           for(let x=0; x<l; x++){
             const y = view[x]
-            range_min = Math.min(range_min, sample_arr[y])
-            range_max = Math.max(range_max, sample_arr[y])
+            if(!isNaN(sample_arr[y])){
+              range_min = Math.min(range_min, sample_arr[y])
+              range_max = Math.max(range_max, sample_arr[y])
+            }
           }
           if(range_min == range_max){
             range_min -= 1

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -82,7 +82,7 @@ export class HistogramCDS extends ColumnarDataSource {
           let range_max = -Infinity
           const l = sample_arr.length
           for(let x=0; x<l; x++){
-            if(!isNaN(sample_arr[x])){
+            if(isFinite(sample_arr[x])){
               range_min = Math.min(range_min, sample_arr[x])
               range_max = Math.max(range_max, sample_arr[x])
             }
@@ -109,7 +109,7 @@ export class HistogramCDS extends ColumnarDataSource {
           const l = this.view.length
           for(let x=0; x<l; x++){
             const y = view[x]
-            if(!isNaN(sample_arr[y])){
+            if(isFinite(sample_arr[y])){
               range_min = Math.min(range_min, sample_arr[y])
               range_max = Math.max(range_max, sample_arr[y])
             }

--- a/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistogramCDS.ts
@@ -91,6 +91,10 @@ export class HistogramCDS extends ColumnarDataSource {
             range_min -= 1
             range_max += 1
           }
+          if(!isFinite(range_min)){
+            range_min = 0
+            range_max = 1
+          }
           this._range_min = range_min
           this._range_max = range_max
         } else {
@@ -117,6 +121,10 @@ export class HistogramCDS extends ColumnarDataSource {
           if(range_min == range_max){
             range_min -= 1
             range_max += 1
+          }
+          if(!isFinite(range_min)){
+            range_min = 0
+            range_max = 1
           }
           this._range_min = range_min
           this._range_max = range_max

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Compression.py
@@ -127,7 +127,7 @@ def test_Compression0():
 
 @pytest.mark.unittest
 def test_CompressionSequence0(arraySize=10000):
-    actionArray=[("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["int8","int16", "int32", "int64", "float32", "float64"]:
         actionArray[3]=("unzip",coding)
         arrayInput=pd.Series(np.arange(0,arraySize,1,dtype=coding))
@@ -140,7 +140,7 @@ def test_CompressionSequence0(arraySize=10000):
 
 @pytest.mark.unittest
 def test_CompressionSequenceRel(arraySize=255,nBits=5):
-    actionArray=[("relative",nBits), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("relative",nBits), ("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["int8","int16", "int32", "int64", "float32", "float64"]:
         actionArray[4]=("unzip",coding)
         arrayInput=pd.Series(np.arange(0,arraySize,1,dtype=coding))
@@ -153,7 +153,7 @@ def test_CompressionSequenceRel(arraySize=255,nBits=5):
 
 @pytest.mark.unittest
 def test_CompressionSequenceAbs(arraySize=255,delta=0.1):
-    actionArray=[("delta",delta), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("delta",delta), ("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["int8","int16", "int32", "int64", "float32", "float64"]:
         actionArray[4]=("unzip",coding)
         arrayInput=pd.Series(np.arange(0,arraySize,1,dtype=coding))
@@ -167,7 +167,7 @@ def test_CompressionSequenceAbs(arraySize=255,delta=0.1):
 
 @pytest.mark.unittest
 def test_CompressionSample0(arraySize=10000,scale=255):
-    actionArray=[("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["int8","int16", "int32", "int64", "float32", "float64"]:
         actionArray[3]=("unzip",coding)
         arrayInput=pd.Series((np.random.random_sample(size=arraySize)*scale).astype(coding))
@@ -180,7 +180,7 @@ def test_CompressionSample0(arraySize=10000,scale=255):
 
 @pytest.mark.unittest
 def test_CompressionSampleRel(arraySize=10000,scale=255, nBits=7):
-    actionArray=[("relative",nBits), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("relative",nBits), ("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["float32", "float64"]:
         actionArray[4]=("unzip",coding)
         arrayInput=pd.Series((np.random.random_sample(size=arraySize)*scale).astype(coding))
@@ -193,7 +193,7 @@ def test_CompressionSampleRel(arraySize=10000,scale=255, nBits=7):
 
 @pytest.mark.unittest
 def test_CompressionSampleDelta(arraySize=10000,scale=255, delta=1):
-    actionArray=[("delta",delta), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8")]
+    actionArray=[("delta",delta), ("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8")]
     for coding in ["float32", "float64"]:
         actionArray[4]=("unzip",coding)
         arrayInput=pd.Series((np.random.random_sample(size=arraySize)*scale).astype(coding))
@@ -206,7 +206,7 @@ def test_CompressionSampleDelta(arraySize=10000,scale=255, delta=1):
 
 @pytest.mark.unittest
 def test_CompressionSampleDeltaCode(arraySize=10000,scale=255, delta=1):
-    actionArray=[("delta",delta), ("code",0), ("zip",0), ("base64",0), ("debase64",0),("unzip","int8"),("decode",0)]
+    actionArray=[("delta",delta), ("code",0), ("zip",0), ("base64",0), ("base64_decode",0),("unzip","int8"),("decode",0)]
     for coding in ["float32", "float64"]:
         #actionArray[5]=("unzip",coding)
         arrayInput=pd.Series((np.random.random_sample(size=arraySize)*scale).astype(coding))


### PR DESCRIPTION
This PR:
-Makes infinite values not count for auto ranges in histograms
-Removes NaN when computing mean and std
-Simplifies the interface for array compression - TODO: remove the need for "base64" at the end and ignore if it's specified as the last step for back compatibility reasons