### PR TITLE
Rdataframe makeDefine

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSCompress.ts
@@ -188,6 +188,15 @@ export class CDSCompress extends ColumnDataSource {
     return arrOut;
   }
 
+  get_array(key: string) {
+    let column = this.get_column(key)
+    if (column == null)
+        return []
+    else if (!Array.isArray(column))
+        return Array.from(column)
+    return column;
+  }
+
   get_length(){
     if (this._length !== -1) return this._length
     for(const key in this.inputData){

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -84,7 +84,7 @@ export class RangeFilter extends Model {
       new_vector[i] = a
       has_element ||= a
     }
-    if(has_element){
+    if(!has_element){
       console.warn("Range empty: " + field)
     }
     this.dirty_source = false

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -78,15 +78,14 @@ export class RangeFilter extends Model {
     const index_low = this.index_low
     const index_high = this.index_high === -1 ? col.length : this.index_high
     const [low, high] = this.range
-    let is_empty = true
+    let has_element = false
     for(let i=index_low; i<index_high; i++){
       const a = (col[i] >= low) && (col[i] <= high)
       new_vector[i] = a
-      is_empty &&= !a
+      has_element ||= a
     }
-    if(is_empty){
+    if(has_element){
       console.warn("Range empty: " + field)
-      return cached_vector
     }
     this.dirty_source = false
     this.dirty_widget = false

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -78,8 +78,15 @@ export class RangeFilter extends Model {
     const index_low = this.index_low
     const index_high = this.index_high === -1 ? col.length : this.index_high
     const [low, high] = this.range
+    let is_empty = true
     for(let i=index_low; i<index_high; i++){
-        new_vector[i] = (col[i] >= low) && (col[i] <= high)
+      const a = (col[i] >= low) && (col[i] <= high)
+      new_vector[i] = a
+      is_empty &&= !a
+    }
+    if(is_empty){
+      console.warn("Range empty: " + field)
+      return cached_vector
     }
     this.dirty_source = false
     this.dirty_widget = false

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -241,7 +241,7 @@ class RDataFrame_Visit:
         body = self.visit(node.body)
         return {
             "implementation":f"""auto {self.name}(){{
-    {self.makeOuterLoop(0, f'{body["implementation"]}', body["type"])}
+    {self.makeOuterLoop(0, body["implementation"], body["type"])}
 }} """,
         }
 
@@ -250,7 +250,7 @@ class RDataFrame_Visit:
         template_end_f = ''.join([">" for i in range(depth, len(self.n_iter))])
         depth_f = f"_{depth}" if depth>0 else ""
         depth_f_lower = f"_{depth-1}" if depth>1 else ""
-        expr_f = f"result{depth_f_lower}[i{depth_f_lower}] = result{depth_f}" if depth>0 else ""
+        expr_f = f"result{depth_f_lower}[i{depth_f_lower}] = result{depth_f};" if depth>0 else ""
         if depth>=len(self.n_iter):
             depth_f = f"_{depth-1}" if depth>1 else ""
             return f"result{depth_f}[i{depth_f}] = {innerLoop};"

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -71,8 +71,7 @@ class RDataFrame_Visit:
         implementation += ')'
         return {
             "implementation": implementation,
-            "type": "javascript",
-            "name": self.code
+            "type": left["type"]
         }
 
     def visit_Num(self, node: ast.Num):
@@ -269,6 +268,9 @@ class RDataFrame_Visit:
         raise NotImplementedError(f"{ast.dump(node)} is not supported as a function")
 
     def visit_func_Name(self, node:ast.Name, args):
+        if self.df:
+            func = getGlobalFunction(node.id)
+            return {"type":"function", "implementation":node.id, "type":func["returnType"]}
         return {"type":"function", "implementation":node.id, "type":"double"}
 
     def visit_func_Attribute(self, node:ast.Attribute, args):
@@ -297,4 +299,5 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
     if df is not None and not isTest:
         df.Define(name, parsed["implementation"], list(evaluator.dependencies))
 
-makeDefine("C","cos(A[1:10,2:6])-B[:20:2]", None,3, True)
+makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
+makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -253,7 +253,7 @@ class RDataFrame_Visit:
         expr_f = f"result{depth_f_lower}[i{depth_f_lower}] = result{depth_f}" if depth>0 else ""
         if depth>=len(self.n_iter):
             depth_f = f"_{depth-1}" if depth>1 else ""
-            return f"result{depth_f}[i{depth_f}] = {innerLoop}"
+            return f"result{depth_f}[i{depth_f}] = {innerLoop};"
         return f"""{template_begin_f}{dtype}{template_end_f} result{depth_f}({self.n_iter[depth]});
     for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[depth]}; i{depth_f}++){{
         {self.makeOuterLoop(depth+1, innerLoop, dtype)}

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -299,5 +299,5 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
     if df is not None and not isTest:
         df.Define(name, parsed["implementation"], list(evaluator.dependencies))
 
-makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
-makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
+# makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
+# makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -254,8 +254,8 @@ class RDataFrame_Visit:
         if depth>=len(self.n_iter):
             depth_f = f"_{depth-1}" if depth>1 else ""
             return f"result{depth_f}[i{depth_f}] = {innerLoop}"
-        return f"""{template_begin_f}{dtype}{template_end_f} result{depth_f}({self.n_iter[0]});
-    for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[0]}; i{depth_f}++){{
+        return f"""{template_begin_f}{dtype}{template_end_f} result{depth_f}({self.n_iter[depth]});
+    for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[depth]}; i{depth_f}++){{
         {self.makeOuterLoop(depth+1, innerLoop, dtype)}
     }}
     {expr_f}"""

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -255,8 +255,8 @@ auto {self.name}(){{
         depth_f = f"_{depth}" if depth>0 else ""
         return f"""
     {template_begin_f}{dtype}{template_end_f} result{depth_f}({self.n_iter[0]});
-    for(size_t i=0; i<{self.n_iter[0]}; i++){{
-        result[i] = {self.makeOuterLoop(depth+1, innerLoop, dtype)};
+    for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[0]}; i{depth_f}++){{
+        result[i{depth_f}] = {self.makeOuterLoop(depth+1, innerLoop, dtype)};
     }}
         """
 
@@ -297,4 +297,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
     if df is not None and not isTest:
         df.Define(name, parsed["implementation"], list(evaluator.dependencies))
 
-makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
+makeDefine("C","cos(A[1:10,2:11])-B[:20:2]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -302,4 +302,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
         df.Define(name, parsed["implementation"], list(evaluator.dependencies))
 
 # makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
-makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
+# makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)


### PR DESCRIPTION
This PR:
-Adds error handling to range filters in javascript, console logging a warning if the range is empty
-Adds support for global functions and arrays of arrays in makeDefine
Example:
```python
makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
```
Output

Implementation:
```c++
 auto C(){
    RVec<RVec<double>> result(10);
    for(size_t i=0; i<10; i++){
        RVec<double> result_1(2);
    for(size_t i_1=0; i_1<2; i_1++){
        result_1[i_1] = (cos(A[1+i*1])) - (B[0+i*2][1+i_1*1]);
    }
    result[i] = result_1;
    }

}
```
Dependencies
 ['B', 'A']
