### PR TITLE
makeDefine support for detecting output type -> #293

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -327,7 +327,7 @@ class ColumnEvaluator:
             operator_infix = " - "
         elif isinstance(op, ast.Mult):
             operator_infix = " * "
-        elif isinstance(op, ast.Div):
+        elif isinstance(op, ast.Div) or isinstance(op, ast.FloorDiv):
             operator_infix = " / "
         elif isinstance(op, ast.Mod):
             operator_infix = " % "
@@ -348,6 +348,8 @@ class ColumnEvaluator:
         else:
             raise NotImplementedError(f"Binary operator {ast.dump(op)} not implemented for expressions on the client")
         implementation = f"({self.visit(node.left)['implementation']}){operator_infix}({self.visit(node.right)['implementation']})"
+        if isinstance(op, ast.FloorDiv):
+            implementation = f"(({implementation})|0)"
         return {
             "name": self.code,
             "type": "javascript",

--- a/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/compileVarName.py
@@ -362,8 +362,10 @@ class ColumnEvaluator:
             operator_prefix = "+"
         elif isinstance(op, ast.USub):
             operator_prefix = "-"
-        else:
+        elif isinstance(op, ast.Not):
             operator_prefix = "!"
+        elif isinstance(op, ast.Invert):
+            operator_prefix = "~"
         implementation = f"{operator_prefix}({self.visit(node.operand)['implementation']})"
         return {
             "name": self.code,

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -38,7 +38,7 @@ def getClassMethod(className, methodName, arguments=[]):
     import re
     try:
         docString= eval(f"ROOT.{className}.{methodName}.func_doc")
-        returnType = re.sub(f"{className}.*","",docString)
+        returnType = re.sub(f"\\s{className}.*","",docString)
         return (returnType,docString)
     except:
         pass

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -355,6 +355,7 @@ class RDataFrame_Visit:
     return result;
 }} """,
 "type": array_type,
+"name": self.name,
 "dependencies": [i[0] for i in dependencies_list]
         }
 

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -56,7 +56,7 @@ def scalar_type(name):
         "int": ('i', 32),
         "char": ('i', 8)
     }
-    return dtypes[name]
+    return dtypes.get(name, name)
 
 def scalar_type_str(dtype):
     dtypes = {
@@ -261,7 +261,7 @@ class RDataFrame_Visit:
             elif isinstance(op, ast.GtE):
                 op_infix = " >= "
             else:
-                raise NotImplementedError(f"Binary operator {ast.dump(op)} not implemented")
+                raise NotImplementedError(f"Comparison operator {ast.dump(op)} not implemented")
             js_comparisons.append(f"(({lhs}){op_infix}({rhs}))")
         implementation = " && ".join(js_comparisons)
         return {

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -350,7 +350,7 @@ class RDataFrame_Visit:
         input_args = ', '.join([f"{value['type']} &{key}" for key, value in dependencies_list])
         signature = f"{array_type} {self.name}({input_args})"
         return {
-            "implementation":f"""{signature}){{
+            "implementation":f"""{signature}{{
     {loop}
     return result;
 }} """,

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -286,8 +286,9 @@ class RDataFrame_Visit:
         loop, array_type = self.makeOuterLoop(0, body["implementation"], body["type"])
         dependencies_list = [(key, value) for key, value in self.dependencies.items()]
         input_args = ', '.join([f"{value['type']} &{key}" for key, value in dependencies_list])
+        signature = f"{array_type} {self.name}({input_args})"
         return {
-            "implementation":f"""{array_type} {self.name}({input_args}){{
+            "implementation":f"""{signature}){{
     {loop}
     return result;
 }} """,

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -1,5 +1,5 @@
 import ast
-# import ROOT
+import ROOT
 
 def getGlobalFunction(name="cos", verbose=0):
     info={"fun":0, "returnType":"", "nArgs":0}
@@ -371,4 +371,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
 
 # makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
 # makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
-makeDefine("B","A[1:]-A[:-1]", None,3, True)
+# makeDefine("B","A[1:]-A[:-1]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -391,7 +391,9 @@ class RDataFrame_Visit:
 
     def visit_func_Attribute(self, node:ast.Attribute, args):
         left = self.visit(node.value)
-        return {"type":"function", "implementation":f"{left['implementation']}.{node.attr}"}
+        className = left["type"]
+        (returnType, docstring) = getClassMethod(className, node.attr, args)
+        return {"type":"function", "implementation":f"{left['implementation']}.{node.attr}", "returnType":returnType}
 
     def visit_Tuple(self, node:ast.Tuple):
         # So far, the only tuple supported is a slice tuple

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -340,8 +340,9 @@ class RDataFrame_Visit:
                 self.n_iter[idx] = f"{value['implementation']}.size() - {-n_iter}"
             else:
                 self.n_iter[idx] = n_iter
-        print(len(n_iter_arr), n_iter_arr)
-        dtype = scalar_type(unpackScalarType(value["type"], len(n_iter_arr)))
+        dtype_str = unpackScalarType(value["type"], len(n_iter_arr))
+        dtype = scalar_type(dtype_str)
+        print(dtype_str, dtype)
         return {
             "implementation":f"{value['implementation']}[{sliceValue['implementation']}]",
             "type":dtype

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -411,7 +411,7 @@ class RDataFrame_Visit:
 def unpackScalarType(vecType:str, level:int=0):
     if level <= 0:
         return vecType
-    vecTypeNew = vecType.split('<',1)[1].split('>')[-2]
+    vecTypeNew = vecType.split('<',1)[1].rsplit('>',1)[-2]
     return unpackScalarType(vecTypeNew, level-1)
 
 def makeDefine(name, code, df, verbose=3, isTest=False):

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -1,5 +1,5 @@
 import ast
-import ROOT
+# import ROOT
 
 def getGlobalFunction(name="cos", verbose=0):
     info={"fun":0, "returnType":"", "nArgs":0}
@@ -272,7 +272,7 @@ class RDataFrame_Visit:
                 self.n_iter.append(n_iter)
             # Detect if length needs to be used here
             if n_iter <= 0:
-                self.n_iter[idx] = f"{value['implementation']}.size() - ({n_iter})"
+                self.n_iter[idx] = f"{value['implementation']}.size() - {-n_iter}"
             else:
                 self.n_iter[idx] = n_iter
         dtype = unpackScalarType(value["type"])
@@ -371,4 +371,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
 
 # makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
 # makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
-# makeDefine("B","A[1:]-A[:-1]", None,3, True)
+makeDefine("B","A[1:]-A[:-1]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -1,5 +1,5 @@
 import ast
-#import ROOT
+import ROOT
 
 def getGlobalFunction(name="cos", verbose=0):
     info={"fun":0, "returnType":"", "nArgs":0}
@@ -271,7 +271,10 @@ class RDataFrame_Visit:
             if len(self.n_iter) <= idx:
                 self.n_iter.append(n_iter)
             # Detect if length needs to be used here
-            self.n_iter[idx] = n_iter
+            if n_iter <= 0:
+                self.n_iter[idx] = f"{value['implementation']}.size() - ({n_iter})"
+            else:
+                self.n_iter[idx] = n_iter
         dtype = unpackScalarType(value["type"])
         return {
             "implementation":f"{value['implementation']}[{sliceValue['implementation']}]",
@@ -367,4 +370,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
 
 # makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
 # makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
-makeDefine("B","A[1:]-A[:-1]", None,3, True)
+# makeDefine("B","A[1:]-A[:-1]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -38,7 +38,7 @@ def getClassMethod(className, methodName, arguments=[]):
     import re
     try:
         docString= eval(f"ROOT.{className}.{methodName}.func_doc")
-        returnType = re.sub(f"\\s{className}.*","",docString)
+        returnType = re.sub(f"\\s+{className}.*","",docString)
         return (returnType,docString)
     except:
         pass

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -49,6 +49,7 @@ def scalar_type(name):
     dtypes = {
         "float": ('f', 32),
         "double": ('f', 64),
+        "long double": ('f', 64),
         "size_t": ('u', 64),
         "long long": ('i', 64),
         "unsigned int": ('u', 32),

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -340,6 +340,7 @@ class RDataFrame_Visit:
                 self.n_iter[idx] = f"{value['implementation']}.size() - {-n_iter}"
             else:
                 self.n_iter[idx] = n_iter
+        print(len(n_iter_arr), n_iter_arr)
         dtype = scalar_type(unpackScalarType(value["type"], len(n_iter_arr)))
         return {
             "implementation":f"{value['implementation']}[{sliceValue['implementation']}]",
@@ -404,7 +405,6 @@ class RDataFrame_Visit:
 
     def visit_ExtSlice(self, node:ast.ExtSlice):
         x = [self.visit_Slice(iSlice, i) for i, iSlice in enumerate(node.dims)]
-        print(str(x))
         return {"type":"int*", "implementation":']['.join([i["implementation"] for i in x]), "n_iter": [i["n_iter"] for i in x], "high_water": [i["high_water"] for i in x]}       
 
 def unpackScalarType(vecType:str, level:int=0):

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -404,6 +404,7 @@ class RDataFrame_Visit:
 
     def visit_ExtSlice(self, node:ast.ExtSlice):
         x = [self.visit_Slice(iSlice, i) for i, iSlice in enumerate(node.dims)]
+        print(str(x))
         return {"type":"int*", "implementation":']['.join([i["implementation"] for i in x]), "n_iter": [i["n_iter"] for i in x], "high_water": [i["high_water"] for i in x]}       
 
 def unpackScalarType(vecType:str, level:int=0):

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -411,7 +411,7 @@ class RDataFrame_Visit:
 def unpackScalarType(vecType:str, level:int=0):
     if level <= 0:
         return vecType
-    vecTypeNew = vecType.split('<',1)[1][:-1]
+    vecTypeNew = vecType.split('<',1)[1].split('>')[-2]
     return unpackScalarType(vecTypeNew, level-1)
 
 def makeDefine(name, code, df, verbose=3, isTest=False):

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -115,6 +115,8 @@ class RDataFrame_Visit:
             return self.visit_Subscript(node)
         elif isinstance(node, ast.Slice):
             return self.visit_Slice(node)
+        elif isinstance(node, ast.ExtSlice):
+            return self.visit_ExtSlice(node)
         elif isinstance(node, ast.Tuple):
             return self.visit_Tuple(node)
         elif isinstance(node, ast.Constant):
@@ -400,6 +402,10 @@ class RDataFrame_Visit:
         x = [self.visit_Slice(iSlice, i) for i, iSlice in enumerate(node.elts)]
         return {"type":"int*", "implementation":']['.join([i["implementation"] for i in x]), "n_iter": [i["n_iter"] for i in x], "high_water": [i["high_water"] for i in x]}
 
+    def visit_ExtSlice(self, node:ast.ExtSlice):
+        x = [self.visit_Slice(iSlice, i) for i, iSlice in enumerate(node.dims)]
+        return {"type":"int*", "implementation":']['.join([i["implementation"] for i in x]), "n_iter": [i["n_iter"] for i in x], "high_water": [i["high_water"] for i in x]}       
+
 def unpackScalarType(vecType:str, level:int=0):
     if level <= 0:
         return vecType
@@ -437,4 +443,4 @@ def makeDefine(name, code, df, verbose=3, isTest=False):
 
 # makeDefine("C","cos(A[1:10])-B[:20:2]", None,3, True)
 # makeDefine("C","cos(A[1:10])-B[:20:2,1:3]", None,3, True)
-# makeDefine("B","A[:]/(B[:])", None,3, True)
+# makeDefine("B","array2D0[1:10,:]-array2D1[1:10,:]", None,3, True)

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -98,10 +98,18 @@ def test_define1D(rdf, name, expression,verbosity):
     parsed = makeDefine("arrayCosAll","cos(array1D0[:])", rdf,3, True);
     rdf = makeDefineRDFv2("arrayCosAll", parsed["name"], parsed,  rdf, verbose=1)
     rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameCosAll.root");
-    # test 4  - 1D member function failing
+    # test 4  - 1D member function OK
     parsed = makeDefine("arrayPx","array1DTrack[1:10].Px()", rdf,3, True);
     rdf = makeDefineRDFv2("arrayPx", parsed["name"], parsed,  rdf, verbose=1)
     rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameArrayPx.root");
+    # test 5  - 2D delta auto range
+    parsed = makeDefine("arrayD2D","array2D0[1:10,:]-array2D1[1:10,:]", rdf,3, True);
+    rdf = makeDefineRDFv2("arrayD2D", parsed["name"], parsed,  rdf, verbose=1)
+    rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameArrayD2D.root");
+    # test 6  - 2D delta against 1D
+    parsed = makeDefine("arrayD1D2D","array2D0[:,:]-array1D0[:]", rdf,3, True);
+    rdf = makeDefineRDFv2("arrayD1D2D", parsed["name"], parsed,  rdf, verbose=1)
+    rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameArrayD1D2D.root");
     # Test of invarainces
     # tt.Draw("arrayCosAll:cos(array1D0)","arrayCos0!=0","*")
     # entries = tt.Draw("arrayCosAll-cos(array1D0)","","");

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -103,7 +103,6 @@ def test_define1D(rdf, name, expression,verbosity):
     parsed = makeDefine("arrayPx","array1DTrack[1:10].Px()", rdf,3, True);
     rdf = makeDefineRDFv2("arrayPx", parsed["name"], parsed,  rdf, verbose=1)
     rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameArrayPx.root");
-<<<<<<< HEAD
     # test 5  - 2D delta auto range
     parsed = makeDefine("arrayD2D","array2D0[1:10,:]-array2D1[1:10,:]", rdf,3, True);
     rdf = makeDefineRDFv2("arrayD2D", parsed["name"], parsed,  rdf, verbose=1)
@@ -119,12 +118,6 @@ def test_define1D(rdf, name, expression,verbosity):
     # tt.GetHistogram().GetRms()  # should be 0 +- errror  cut e.g 10^-5
     # tt.GetHistogram().GetRms()  # should be 0 +- errorr
 
-=======
-    #
-    parsed = makeDefine("arrayD2D", "array2D0[1:10,:]-array2D1[1:10,:]", rdf, 3, True)
-    rdf = makeDefineRDFv1("arrayD2D", parsed["name"], parsed, rdf, verbose=1)
-    rdf.Snapshot("makeTestRDataFrame","makeTestRDataFrameD2D.root")
->>>>>>> 5940ecca90b2618b39c9d670f2f797eccc29fc43
     return rdf
 
 def getClassMethod(className, methodName):


### PR DESCRIPTION
This PR:
- Fixes a bug with loop variable bounds being wrong because of a wrong sign (RDataFrame)
- Adds support for detecting output type using a dictionary of types (RDataFrame)
- Fixes the behavior of TrueDiv in case integers are used by casting to float (RDataFrame)
- Adds support for FloorDiv and Invert in expressions for bokehDraw (JavaScript)