### PR TITLE
makeJSCallback optimization and bugfixes

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.py
@@ -1,8 +1,8 @@
-from bokeh.model import Model
+from RootInteractive.InteractiveDrawing.bokeh.RIFilter import RIFilter
 from bokeh.core.properties import Instance, String
 from bokeh.models.sources import ColumnarDataSource
 
-class ColumnFilter(Model):
+class ColumnFilter(RIFilter):
     __implementation__ = "ColumnFilter.ts"
 
     source = Instance(ColumnarDataSource, help="Column data source to select from")

--- a/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.ts
@@ -53,7 +53,8 @@ export class ColumnFilter extends RIFilter {
     if (!dirty_source){
         return cached_vector
     }
-    let col = source.get_array(field)
+    let col = source.get_column(field)
+    if(col == null) return []
     let new_vector: boolean[] = this.cached_vector
     if (new_vector == null){
         new_vector = Array(col.length)

--- a/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ColumnFilter.ts
@@ -1,11 +1,11 @@
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
-import {Model} from "model"
+import {RIFilter} from "./RIFilter"
 import * as p from "core/properties"
 
 export namespace ColumnFilter {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Model.Props & {
+  export type Props = RIFilter.Props & {
     source: p.Property<ColumnarDataSource>
     field:p.Property<string>
   }
@@ -13,7 +13,7 @@ export namespace ColumnFilter {
 
 export interface ColumnFilter extends ColumnFilter.Attrs {}
 
-export class ColumnFilter extends Model {
+export class ColumnFilter extends RIFilter {
   properties: ColumnFilter.Props
 
   constructor(attrs?: Partial<ColumnFilter.Attrs>) {

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.py
@@ -1,6 +1,6 @@
-from bokeh.core.properties import Instance, String, Int, Bool
+from bokeh.core.properties import Instance, Int, Bool
 from bokeh.models import ColumnarDataSource
-
+from RootInteractive.InteractiveDrawing.bokeh.CDSAlias import CDSAlias
 
 class DownsamplerCDS(ColumnarDataSource):
 
@@ -14,7 +14,7 @@ class DownsamplerCDS(ColumnarDataSource):
     #
     #    https://docs.bokeh.org/en/latest/docs/reference/core/properties.html#bokeh-core-properties
 
-    source = Instance(ColumnarDataSource)
+    source = Instance(CDSAlias)
     nPoints = Int(default=300, help="Number of points to downsample CDS to")
     watched = Bool()
     print("Import ", __implementation__)

--- a/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/DownsamplerCDS.ts
@@ -1,11 +1,12 @@
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
+import {CDSAlias} from "./CDSAlias"
 import * as p from "core/properties"
 
 export namespace DownsamplerCDS {
   export type Attrs = p.AttrsOf<Props>
 
   export type Props = ColumnarDataSource.Props & {
-    source: p.Property<ColumnarDataSource>
+    source: p.Property<CDSAlias>
     nPoints: p.Property<number>
     watched: p.Property<boolean>
   }
@@ -24,7 +25,7 @@ export class DownsamplerCDS extends ColumnarDataSource {
 
   static init_DownsamplerCDS() {
     this.define<DownsamplerCDS.Props>(({Ref, Int, Boolean})=>({
-      source:  [Ref(ColumnarDataSource)],
+      source:  [Ref(CDSAlias)],
       nPoints:    [ Int, 300 ],
       watched: [Boolean, true]
     }))
@@ -43,14 +44,13 @@ export class DownsamplerCDS extends ColumnarDataSource {
     this.booleans = null
     this._indices = []
     this.data = {}
-    this.shuffle_indices()
     this.update()
   }
 
   shuffle_indices(){
     const {_indices, source} = this
     _indices.length = source.get_length()!
-    // Deck shuffling algorithm - for each card drawn, swap it with a random card in hand
+    // Fisher-Yates random permutation
     for(let i=0; i<_indices.length; ++i){
       let random_index = (Math.random()*(i+1)) | 0
       _indices[i] = i

--- a/RootInteractive/InteractiveDrawing/bokeh/LazyIntersectionFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/LazyIntersectionFilter.py
@@ -1,0 +1,8 @@
+from RootInteractive.InteractiveDrawing.bokeh.RIFilter import RIFilter
+from bokeh.core.properties import List, Instance
+
+class LazyIntersectionFilter(RIFilter):
+    __implementation__ = "LazyIntersectionFilter.ts"
+
+    filters = List(Instance(RIFilter))
+

--- a/RootInteractive/InteractiveDrawing/bokeh/LazyIntersectionFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/LazyIntersectionFilter.ts
@@ -1,0 +1,93 @@
+import {RIFilter} from "./RIFilter"
+import * as p from "core/properties"
+
+export namespace LazyIntersectionFilter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = RIFilter.Props & {
+    filters: p.Property<RIFilter[]>
+  }
+}
+
+export interface LazyIntersectionFilter extends LazyIntersectionFilter.Attrs {}
+
+export class LazyIntersectionFilter extends RIFilter {
+  properties: LazyIntersectionFilter.Props
+
+  constructor(attrs?: Partial<LazyIntersectionFilter.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "LazyIntersectionFilter"
+
+  static init_LazyIntersectionFilter() {
+    this.define<LazyIntersectionFilter.Props>(({Ref, Array})=>({
+      filters:  [Array(Ref(RIFilter)), []],
+    }))
+  }
+
+  changed: Set<number>
+  counts: number[]
+  cached_vector: boolean[]
+  old_values: boolean[][]
+
+  initialize(){
+    super.initialize()
+    this.changed = new Set()
+    for(let i=0; i<this.filters.length; i++){
+        this.changed.add(i)
+    }
+    this.old_values = []
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+
+    for (let i=0; i<this.filters.length; i++) {
+        this.connect(this.filters[i].change, ()=>this.changed.add(i))
+    }
+  }
+
+  public v_compute(): boolean[]{
+    let {cached_vector, filters} = this
+    if (this.changed.size === 0 && cached_vector != null){
+        return cached_vector
+    }
+    for(const x of this.changed){
+        if(this.old_values.length <= x){
+            this.old_values.length = x+1
+        }
+        if(this.old_values[x] == undefined){
+            this.old_values[x] = []
+        }
+        const values = filters[x].v_compute()
+        while(this.old_values[x].length < values.length){
+            this.old_values[x].push(true)
+        }
+        if(this.counts == null){
+            this.counts = Array(values.length).fill(0)
+        }
+        this.counts.length = values.length
+        const invert = filters[x].invert
+        const old_values = this.old_values[x]
+        for(let i=0; i<values.length; i++){
+            const new_value = values[i]!==invert
+            this.counts[i] += new_value ? 1 : 0
+            this.counts[i] -= old_values[i] ? 1 : 0
+            old_values[i] = new_value
+        }
+    }
+    this.changed.clear()
+    let new_vector: boolean[] = this.cached_vector
+    if (new_vector == null){
+        new_vector = Array(this.counts.length)
+    } else {
+        new_vector.length = this.counts.length
+    }
+    for(let i=0; i<this.counts.length; i++){
+        new_vector[i] = !this.counts[i]
+    }
+    this.cached_vector = new_vector
+    return new_vector
+  }
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.py
@@ -1,8 +1,8 @@
-from bokeh.model import Model
+from RootInteractive.InteractiveDrawing.bokeh.RIFilter import RIFilter
 from bokeh.core.properties import Instance, String, Dict, List, Int
 from bokeh.models.sources import ColumnarDataSource
 
-class MultiSelectFilter(Model):
+class MultiSelectFilter(RIFilter):
     __implementation__ = "MultiSelectFilter.ts"
 
     source = Instance(ColumnarDataSource, help="Column data source to select from")

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -1,11 +1,11 @@
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
-import {Model} from "model"
+import {RIFilter} from "./RIFilter"
 import * as p from "core/properties"
 
 export namespace MultiSelectFilter {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Model.Props & {
+  export type Props = RIFilter.Props & {
     source: p.Property<ColumnarDataSource>
     selected: p.Property<string[]>
     mapping: p.Property<Record<string, number>>
@@ -17,7 +17,7 @@ export namespace MultiSelectFilter {
 
 export interface MultiSelectFilter extends MultiSelectFilter.Attrs {}
 
-export class MultiSelectFilter extends Model {
+export class MultiSelectFilter extends RIFilter {
   properties: MultiSelectFilter.Props
 
   constructor(attrs?: Partial<MultiSelectFilter.Attrs>) {

--- a/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/MultiSelectFilter.ts
@@ -67,7 +67,7 @@ export class MultiSelectFilter extends RIFilter {
     if (!dirty_source && !dirty_widget){
         return cached_vector
     }
-    let col = source.get_array(field)
+    let col = source.get_column(field) as number[]
     let new_vector: boolean[] = this.cached_vector
     if (new_vector == null){
         new_vector = Array(col.length)

--- a/RootInteractive/InteractiveDrawing/bokeh/RIFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/RIFilter.py
@@ -1,0 +1,10 @@
+from bokeh.model import Model
+from bokeh.core.properties import Bool
+
+class RIFilter(Model):
+    __implementation__ = "RIFilter.ts"
+    # This class is a utility class that makes no sense to instantiate on its own
+
+    active = Bool(True, help="The linear part of the transformation")
+    invert = Bool(False, help="The constant component")
+

--- a/RootInteractive/InteractiveDrawing/bokeh/RIFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RIFilter.ts
@@ -1,0 +1,43 @@
+import {Model} from "model"
+import * as p from "core/properties"
+
+export namespace RIFilter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    active: p.Property<boolean>
+    invert: p.Property<boolean>
+  }
+}
+
+export interface RIFilter extends RIFilter.Attrs {}
+
+export class RIFilter extends Model {
+  properties: RIFilter.Props
+
+  constructor(attrs?: Partial<RIFilter.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "RIFilter"
+
+  static init_RIFilter() {
+    this.define<RIFilter.Props>(({Boolean})=>({
+      active:  [Boolean, true],
+      invert: [Boolean, false]
+    }))
+  }
+
+  initialize(){
+    super.initialize()
+  }
+
+  connect_signals(): void {
+    super.connect_signals()
+
+  }
+
+  public v_compute(): boolean[]{
+    return []
+  }
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.py
@@ -1,8 +1,8 @@
-from bokeh.model import Model
+from RootInteractive.InteractiveDrawing.bokeh.RIFilter import RIFilter
 from bokeh.core.properties import Instance, String, Tuple, Float
 from bokeh.models.sources import ColumnarDataSource
 
-class RangeFilter(Model):
+class RangeFilter(RIFilter):
     __implementation__ = "RangeFilter.ts"
 
     source = Instance(ColumnarDataSource, help="Column data source to select from")

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -1,11 +1,11 @@
 import {ColumnarDataSource} from "models/sources/columnar_data_source"
-import {Model} from "model"
+import {RIFilter} from "./RIFilter"
 import * as p from "core/properties"
 
 export namespace RangeFilter {
   export type Attrs = p.AttrsOf<Props>
 
-  export type Props = Model.Props & {
+  export type Props = RIFilter.Props & {
     source: p.Property<ColumnarDataSource>
     field: p.Property<string>
     range: p.Property<number[]>
@@ -14,7 +14,7 @@ export namespace RangeFilter {
 
 export interface RangeFilter extends RangeFilter.Attrs {}
 
-export class RangeFilter extends Model {
+export class RangeFilter extends RIFilter {
   properties: RangeFilter.Props
 
   constructor(attrs?: Partial<RangeFilter.Attrs>) {

--- a/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/RangeFilter.ts
@@ -68,7 +68,7 @@ export class RangeFilter extends RIFilter {
     if (!dirty_source && !dirty_widget){
         return cached_vector
     }
-    let col = source.get_array(field) as number[]
+    let col = source.get_column(field) as number[]
     let new_vector: boolean[] = this.cached_vector
     if (new_vector == null){
         new_vector = Array(col.length)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1211,7 +1211,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     iWidget["filter"].source = cdsFull
                 else:
                     iWidget["filter"].source = cdsOrig    
-                iWidget["widget"].js_on_change("change", callback)
+                iWidget["filter"].js_on_change("change", callback)
         if index is not None:
             index["widget"].js_on_change("value", callback)
         if columns_change_filters:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -28,7 +28,7 @@ from RootInteractive.InteractiveDrawing.bokeh.MultiSelectFilter import MultiSele
 from RootInteractive.InteractiveDrawing.bokeh.LazyTabs import LazyTabs
 from RootInteractive.InteractiveDrawing.bokeh.RangeFilter import RangeFilter
 from RootInteractive.InteractiveDrawing.bokeh.ColumnFilter import ColumnFilter
-from RootInteractive.InteractiveDrawing.bokeh.LazyIntersectionFilter import LazyIntersectionFilter
+#from RootInteractive.InteractiveDrawing.bokeh.LazyIntersectionFilter import LazyIntersectionFilter
 import numpy as np
 import pandas as pd
 import re
@@ -1210,8 +1210,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     columns_change_filters = True
                     iWidget["filter"].source = cdsFull
                 else:
-                    iWidget["filter"].source = cdsOrig
-                
+                    iWidget["filter"].source = cdsOrig    
             iWidget["widget"].js_on_change("value", callback)
         if index is not None:
             index["widget"].js_on_change("value", callback)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1211,7 +1211,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                     iWidget["filter"].source = cdsFull
                 else:
                     iWidget["filter"].source = cdsOrig    
-            iWidget["widget"].js_on_change("value", callback)
+                iWidget["widget"].js_on_change("change", callback)
         if index is not None:
             index["widget"].js_on_change("value", callback)
         if columns_change_filters:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -128,7 +128,7 @@ def makeJScallback(widgetList, cdsOrig, cdsSel, **kwargs):
     console.log(`Filtering took ${t2 - t1} milliseconds.`);
     const view = options.view;
     const histogramList = options.histogramList
-    if(histogramList != []){
+    if(histogramList.length != 0){
         for (let i = 0; i < size; i++){
             if (isSelected[i]){
                 indicesAll.push(i);


### PR DESCRIPTION
This PR:
- Fixes various bugs in makeJSCallback negatively affecting performance
- - test_bokehClientHistogram.py - 5 widgets, 5e6 points, time for selecting points went from 300ms to 60ms
- - ATO-609/trackClusterDumpDraw.ipynb -  3e6 points, 8 widgets, time for selecting points went from 240ms to 60ms
- Fixes a bug with plot title when using custom axis titles
- Fixes a crash that sometimes happens when downsampler is initialized (couldn't reliably reproduce)