### PR TITLE
Replacing deprecated sklearn with scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,6 @@ runtime
 requests
 jupyter
 # ---------------------    machine learning dependencies
-sklearn
+scikit-learn
 xgboost
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'runtime',
         'requests',
         # ---------------------    machine learning dependencies
-        'sklearn',
+        'scikit-learn',
         'scikit-hep',
         "jinja2==3.0.3",
         # ------------------      dependencies needed for test and tutorials in special requirement file requirement_Devel.txt


### PR DESCRIPTION
Recently, I get the following error when installing RootInteractive with pip, using pip-23.0.1
```
Collecting sklearn
  Downloading sklearn-0.0.post1.tar.gz (3.6 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [18 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      
      If the previous advice does not cover your use case, feel free to report it at
      https://github.com/scikit-learn/sklearn-pypi-package/issues/new
      [end of output]
```

Therefore, I suggest to follow the instructions.