### PR TITLE
Predict rf stat

### DIFF
--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -126,7 +126,7 @@ def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=100000):
     if not answers:
         return {}
     merged = {}
-    for key in answers[0].keys:
+    for key in answers[0].keys():
         merged[key] = np.concatenate([i[key] for i in answers])
     return merged
 

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -105,7 +105,7 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
             statOut["trim_mean"][quant]=stats.trim_mean(allRFTranspose,quant,axis=1)
     return statOut
 
-def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=-1):
+def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=100000):
     """
     inspired by https://github.com/scikit-learn/scikit-learn/blob/37ac6788c/sklearn/ensemble/_forest.py#L1410
     predict statistics from random forest

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -37,6 +37,9 @@ def _accumulate_predictionNL(predict, X, out,col):
     prediction = predict(X, check_input=False)
     out[col] += prediction
 
+def simple_predict(predict, X, out, col):
+    out[col] = predict(X, check_input=False)
+
 def partitionBlock(allRF, k, begin, end):
     allRF[begin:end].partition(k)
 
@@ -58,10 +61,9 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     """
     nEstimators = len(rf.estimators_)
     allRF = np.zeros((nEstimators, X.shape[0]))
-    lock = threading.Lock()
     statOut={}
     Parallel(n_jobs=n_jobs, verbose=rf.verbose,require="sharedmem")(
-            delayed(_accumulate_prediction)(e.predict, X, allRF, col,lock)
+            delayed(simple_predict)(e.predict, X, allRF, col)
             for col,e in enumerate(rf.estimators_)
     )
     #

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -60,7 +60,7 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     :return:                    dictionary with requested output statistics
     """
     nEstimators = len(rf.estimators_)
-    allRF = np.zeros((nEstimators, X.shape[0]))
+    allRF = np.empty((nEstimators, X.shape[0]))
     statOut={}
     Parallel(n_jobs=n_jobs, verbose=rf.verbose,require="sharedmem")(
             delayed(simple_predict)(e.predict, X, allRF, col)
@@ -107,7 +107,7 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
             statOut["trim_mean"][quant]=stats.trim_mean(allRFTranspose,quant,axis=1)
     return statOut
 
-def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=100000):
+def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=1000000):
     """
     inspired by https://github.com/scikit-learn/scikit-learn/blob/37ac6788c/sklearn/ensemble/_forest.py#L1410
     predict statistics from random forest


### PR DESCRIPTION
This PR:
-Speeds up predictRFStat by making median/quantile/std parallel
-Reduces memory consumption of predictRFStat by adding a max_rows parameter that splits it into multiple parts to avoid expanding the whole array