### PR TITLE
Linear fitter on the client

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
@@ -1,5 +1,6 @@
 from bokeh.model import Model
-from bokeh.core.properties import String, List, Float
+from bokeh.core.properties import String, List, Float, Instance, Nullable
+from bokeh.models.sources import ColumnarDataSource
 
 class ClientLinearFitter(Model):
     __implementation__ = "ClientLinearFitter.ts"

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
@@ -8,5 +8,5 @@ class ClientLinearFitter(Model):
     source = Instance(ColumnarDataSource, help="The data source to fit from")
     varX = List(String, default=[], help="List of predictors")
     varY = String(help="The variable to predict")
-    eps = Float(default=0, help="Regularization constant for ridge regression")
+    alpha = Float(default=0, help="Regularization constant for ridge regression")
     weights = Nullable(String(), help="Optional weights")

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
@@ -6,7 +6,7 @@ class ClientLinearFitter(Model):
     __implementation__ = "ClientLinearFitter.ts"
 
     source = Instance(ColumnarDataSource, help="The data source to fit from")
-    fields = List(String, default=[], help="List of predictors")
+    varX = List(String, default=[], help="List of predictors")
     varY = String(help="The variable to predict")
     eps = Float(default=0, help="Regularization constant for ridge regression")
     weights = Nullable(String(), help="Optional weights")

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.py
@@ -1,0 +1,11 @@
+from bokeh.model import Model
+from bokeh.core.properties import String, List, Float
+
+class ClientLinearFitter(Model):
+    __implementation__ = "ClientLinearFitter.ts"
+
+    source = Instance(ColumnarDataSource, help="The data source to fit from")
+    fields = List(String, default=[], help="List of predictors")
+    varY = String(help="The variable to predict")
+    eps = Float(default=0, help="Regularization constant for ridge regression")
+    weights = Nullable(String(), help="Optional weights")

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
@@ -1,0 +1,139 @@
+import {Model} from "model"
+import * as p from "core/properties"
+
+export namespace ClientLinearFitter {
+  export type Attrs = p.AttrsOf<Props>
+
+  export type Props = Model.Props & {
+    parameters: p.Property<Record<string, any>>
+    fields: p.Property<Array<string>>
+    func: p.Property<string>
+    v_func: p.Property<string>
+  }
+}
+
+// Cholesky decomposition without pivoting - inplace
+// TODO: Perhaps add a version with pivoting too?
+function chol(X: number[], nRows: number){
+  let iRow = 0
+  let jRow, kRow
+  for(let i=0; i<nRows; ++i){
+    iPivot = i
+    pivotDiag = 1/X[i+iRow]
+    jRow = iRow+i+1
+    for(let j=i+1; j<nRows; ++j) {
+      pivotRow = pivotDiag*X[i+jRow]
+      kRow = iRow+i+1
+      for(let k=i+1; k<=j; ++k){
+	X[k+jRow] -= pivotRow*X[i+kRow]
+	kRow += k+1
+      }
+      kRow = jRow+j+1
+      for(let k=j+1; k<nRows; ++k) {
+	X[j+kRow] -= pivotRow*X[i+kRow]
+	kRow += k+1
+      }
+      X[i+jRow] = pivotRow
+      jRow += j+1
+    }
+    iRow += i+1
+  }
+  return X
+}
+
+// Solves a system of linear equations using Cholesky decomposition
+function solve(x:number[], y:number[]){
+  let nRows = y.length
+  chol(x,nRows)
+  iRow = 0
+  for(let i=0; i<nRows; ++i){
+    for(let j=0; j<i; ++j){
+      y[i] -= y[j]*x[iRow+j]
+    }
+    iRow += i+1
+  }
+  let iDiag=0
+  for(let i=0; i<nRows; i++){
+    y[i] /= x[iDiag]
+    iDiag += i+2
+  }
+  let jRow = 0
+  for(let i=nRows-1; i>=0; --i){
+    jRow = 1+((x*(x+5))>>1)
+    for(let j=i+1; j<nRows; ++j){
+      y[i] -= y[j]*x[jRow]
+      jRow += j+1
+    }
+  }
+  return y
+}
+
+export interface ClientLinearFitter extends ClientLinearFitter.Attrs {}
+
+export class ClientLinearFitter extends Model {
+  properties: ClientLinearFitter.Props
+
+  constructor(attrs?: Partial<ClientLinearFitter.Attrs>) {
+    super(attrs)
+  }
+
+  static __name__ = "ClientLinearFitter"
+
+  static init_ClientLinearFitter() {
+    this.define<ClientLinearFitter.Props>(({Array, String})=>({
+      parameters:  [p.Instance, {}],
+      fields: [Array(String), []],
+      func:    [ String ],
+      v_func:  [String]
+    }))
+  }
+
+  initialize(){
+    super.initialize()
+    this.update_func()
+    this.update_vfunc()
+  }
+
+  args_keys: Array<string>
+  args_values: Array<any>
+
+  scalar_func: Function
+  vector_func: Function
+
+  connect_signals(): void {
+    super.connect_signals()
+  }
+
+  update_func(){
+    this.args_keys = Object.keys(this.parameters)
+    this.args_values = Object.values(this.parameters)
+    this.scalar_func = new Function(...this.args_keys, ...this.fields, '"use strict";\n'+this.func)
+    this.change.emit()
+  }
+
+  compute(x: any[]){
+    return this.scalar_func!(...this.args_values, ...x)
+  }
+
+  update_vfunc(){
+    this.args_keys = Object.keys(this.parameters)
+    this.args_values = Object.values(this.parameters)
+    this.vector_func = new Function(...this.args_keys, ...this.fields, "data_source", "$output",'"use strict";\n'+this.v_func)
+    this.change.emit()
+  }
+
+  update_args(){
+    this.args_keys = Object.keys(this.parameters)
+    this.args_values = Object.values(this.parameters)
+    this.change.emit()
+  }
+
+  v_compute(xs: any[], data_source: any, output: any[] | null =null){
+      if(this.vector_func){
+          return this.vector_func(...this.args_values, ...xs, data_source, output)
+      } else {
+          return null
+      }
+  }
+
+}

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
@@ -251,10 +251,10 @@ export class ClientLinearFitter extends Model {
     if(output != null && output.length === data_source.get_length()){
       output.fill(this.parameters[xs.length])
       for(let i=0; i < xs.length; i++){
-	let x = xs[i]
-	for(let j=0; j < x.length; ++j){
-	  output[j] += x[j]*this.parameters[i]
-	}
+        let x = xs[i]
+        for(let j=0; j < x.length; ++j){
+          output[j] += x[j]*this.parameters[i]
+        }
       } 
     } 
     return output
@@ -264,7 +264,7 @@ export class ClientLinearFitter extends Model {
     if(!this._is_fresh){
       this.fit()
     }
-    let acc = this.parameters.at(-1)!
+    let acc = this.parameters[this.parameters.length-1]!
     for(let i=0; i < xs.length && i < this.parameters.length; i++){
 	 acc += xs[i]*this.parameters[i]
      }

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
@@ -127,6 +127,8 @@ export class ClientLinearFitter extends Model {
       }
       this.parameters.push(acc)
     }
+    x.push(this.source.get_length())
+    this.parameters.push(colY.reduce((acc, cur)=>acc+cur,0))
     solve(x,this.parameters)
   }
 

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
@@ -83,7 +83,7 @@ export class ClientLinearFitter extends Model {
     this.define<ClientLinearFitter.Props>(({Array, String, Number, Ref, Nullable})=>({
       varX: [Array(String), []],
       source: [Ref(ColumnarDataSource)],
-      eps: [Number, 0],
+      alpha: [Number, 0],
       varY: [String],
       weights: [Nullable(String), null]
     }))

--- a/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/ClientLinearFitter.ts
@@ -121,6 +121,7 @@ export class ClientLinearFitter extends Model {
   fit(){
     const {alpha, source, varX, varY, weights} = this
     let x: number[] = []
+    this.parameters = []
     if(weights == null){
     for(let i=0; i < varX.length; ++i){
       let iField = source.get_column(varX[i])
@@ -138,7 +139,6 @@ export class ClientLinearFitter extends Model {
 	x.push(acc)
       }
     }
-    this.parameters = []
     const colY = source.get_column(varY)
     if(colY == null){
       throw ReferenceError("Column not defined: " + this.varY)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -383,7 +383,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         customJsArgList = {}
         transformType = i.get("type", "customJS")
         if transformType == "linearFit":
-            iFitter = jsFunctionDict[i["name"]] = ClientLinearFitter(varY=i["varY"], source=cdsDict[i.get("source", None)]["cdsFull"])
+            iFitter = jsFunctionDict[i["name"]] = ClientLinearFitter(varY=i["varY"], source=cdsDict[i.get("source", None)]["cdsFull"], alpha=i.get("alpha", 0))
             if isinstance(i["varX"], str):
                 if i["varX"] in paramDict:
                     varX = paramDict[i["varX"]]["value"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -381,6 +381,10 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
     jsFunctionDict = {}
     for i in jsFunctionArray:
         customJsArgList = {}
+        transformType = i.get("type", "customJS")
+        if transformType == "linearFit":
+            jsFunctionDict[i["name"]] = ClientLinearFitter(fields=i["varX"], varY=i["varY"], source=i["source"])
+            break
         if isinstance(i["parameters"], list):
             for j in i["parameters"]:
                 customJsArgList[j] = paramDict[j]["value"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1403,7 +1403,7 @@ def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, defau
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
         else:
             dfCategorical = df[params[0]]
-        codes, optionsPlot = pd.factorize(dfCategorical, sort=True)
+        codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
         optionsPlot = optionsPlot.dropna().to_list()
     optionsPlot = [str(i) for i in optionsPlot]
     default_value = 0
@@ -1451,7 +1451,7 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
         else:
             dfCategorical = df[params[0]]
-        codes, optionsPlot = pd.factorize(dfCategorical, sort=True)
+        codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
         optionsPlot = optionsPlot.to_list()
         for i, val in enumerate(optionsPlot):
             optionsPlot[i] = str(val)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -383,7 +383,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         customJsArgList = {}
         transformType = i.get("type", "customJS")
         if transformType == "linearFit":
-            jsFunctionDict[i["name"]] = ClientLinearFitter(fields=i["varX"], varY=i["varY"], source=i["source"])
+            jsFunctionDict[i["name"]] = ClientLinearFitter(fields=i["varX"], varY=i["varY"], source=cdsDict[i.get("source", None)]["cdsFull"])
             break
         if isinstance(i["parameters"], list):
             for j in i["parameters"]:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -383,7 +383,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         customJsArgList = {}
         transformType = i.get("type", "customJS")
         if transformType == "linearFit":
-            iFitter = jsFunctionDict[i["name"]] = ClientLinearFitter(varY=i["varY"], source=cdsDict[i.get("source", None)]["cdsFull"], alpha=i.get("alpha", 0))
+            iFitter = jsFunctionDict[i["name"]] = ClientLinearFitter(varY=i["varY"], source=cdsDict[i.get("source", None)]["cdsFull"], alpha=i.get("alpha", 0), weights=i.get("weights", None))
             if isinstance(i["varX"], str):
                 if i["varX"] in paramDict:
                     varX = paramDict[i["varX"]]["value"]

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -31,6 +31,7 @@ from RootInteractive.InteractiveDrawing.bokeh.LazyTabs import LazyTabs
 from RootInteractive.InteractiveDrawing.bokeh.RangeFilter import RangeFilter
 from RootInteractive.InteractiveDrawing.bokeh.ColumnFilter import ColumnFilter
 from RootInteractive.InteractiveDrawing.bokeh.LazyIntersectionFilter import LazyIntersectionFilter
+from RootInteractive.InteractiveDrawing.bokeh.ClientLinearFitter import ClientLinearFitter
 import numpy as np
 import pandas as pd
 import re

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1388,7 +1388,7 @@ def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, defau
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
         else:
             dfCategorical = df[params[0]]
-        codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
+        codes, optionsPlot = pd.factorize(dfCategorical, sort=True)
         optionsPlot = optionsPlot.dropna().to_list()
     optionsPlot = [str(i) for i in optionsPlot]
     default_value = 0
@@ -1432,7 +1432,7 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
         dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
     else:
         dfCategorical = df[params[0]]
-    codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
+    codes, optionsPlot = pd.factorize(dfCategorical, sort=True)
     optionsPlot = optionsPlot.to_list()
     for i, val in enumerate(optionsPlot):
         optionsPlot[i] = str(val)

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -65,6 +65,8 @@ RE_CURLY_BRACE = re.compile(r"\{(.*?)\}")
 
 RE_VALID_NAME = re.compile(r"^[a-zA-Z_$][0-9a-zA-Z_$]*$")
 
+IS_PANDAS_1 = pd.__version__.split('.')[0] == '1'
+
 def processBokehLayoutArray(widgetLayoutDesc, widgetArray: list, widgetDict: dict={}, isHorizontal: bool=False, options: dict=None):
     """
     apply layout on plain array of bokeh figures, resp. interactive widgets
@@ -1403,7 +1405,10 @@ def makeBokehSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, defau
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
         else:
             dfCategorical = df[params[0]]
-        codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
+        if IS_PANDAS_1:
+            codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
+        else:
+            codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
         optionsPlot = optionsPlot.dropna().to_list()
     optionsPlot = [str(i) for i in optionsPlot]
     default_value = 0
@@ -1451,7 +1456,10 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
         else:
             dfCategorical = df[params[0]]
-        codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
+        if IS_PANDAS_1:
+            codes, optionsPlot = pd.factorize(dfCategorical, sort=True, na_sentinel=None)
+        else:
+            codes, optionsPlot = pd.factorize(dfCategorical, sort=True, use_na_sentinel=False)
         optionsPlot = optionsPlot.to_list()
         for i, val in enumerate(optionsPlot):
             optionsPlot[i] = str(val)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -39,7 +39,9 @@ jsFunctionArray = [
         "name": "linearFit",
         "type": "linearFit",
         "varX": "predictors",
-        "varY": "A_mul_paramX_plus_B"
+        "varY": "A_mul_paramX_plus_B",
+        "alpha": 1e-4,
+        "weights": "C"
     }
 ]
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -33,6 +33,12 @@ jsFunctionArray = [
         "parameters": ["paramX"],
         "fields": ["x", "y"],
         "func": "return paramX*x+y"
+    },
+    {
+        "name": "linearFit",
+        "type": "linearFit",
+        "varX": ["A_mul_paramX_plus_B", "C"],
+        "varY": "B"
     }
 ]
 
@@ -62,11 +68,16 @@ aliasArray = [
     {
         "name": "custom_column",
         "func": "CustomFunc"
+    },
+    {
+        "name": "BPred",
+        "variables": ["A_mul_paramX_plus_B", "C"],
+        "transform": "linearFit"
     }
 ]
 
 figureArray = [
-    [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B', "custom_column"], {"size":"size"}],
+    [['A'], ['B', '4*A+B', 'A_mul_paramX_plus_B', "custom_column", "BPred"], {"size":"size"}],
     [['bin_center'], ['efficiency_A', 'entries_C_cut / bin_count', "C_accepted/bin_count"], {"source":"histoA", "size":"size"}],
     [['bin_center'], ['bin_count', 'entries_C_cut', "C_accepted"], {"source":"histoA", "size":"size", "errY":["sqrt(bin_count)","sqrt(entries_C_cut)","sqrt(C_accepted)"]}],
     [['bin_center_0'], ['efficiency_AC'], {"source":"histoAC", "size":"size", "colorZvar": "bin_center_1"}],
@@ -147,22 +158,13 @@ def test_customJsFunction():
     show(Column(fig, sliderWidget))
 
 def test_customJsFunctionBokehDrawArray():
-    jsFunctionArray = [
-        {
-            "name": "saxpy",
-            "parameters": ["paramX"],
-            "fields": ["x", "y"],
-            "func": "return paramX*x+y"
-        }
-    ]
     output_file("test_AliasBokehDraw.html")
     bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                           widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=300, jsFunctionArray=jsFunctionArray,
                            aliasArray=aliasArray, histogramArray=histoArray)
 
 def test_customJsFunctionBokehDrawArray_v():
-    jsFunctionArray = [
-        {
+    jsFunctionArray[0] = {
             "name": "saxpy",
             "parameters": ["paramX"],
             "fields": ["a", "b"],
@@ -177,7 +179,7 @@ def test_customJsFunctionBokehDrawArray_v():
                 return $output
             """ 
         }
-    ]
+    
     output_file("test_AliasBokehDraw_v.html")
     bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, tooltips=tooltips, parameterArray=parameterArray,
                           widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", nPointRender=300, jsFunctionArray=jsFunctionArray,

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -23,7 +23,8 @@ parameterArray = [
     {"name": "legendFontSize", "value":"13px", "options":["9px", "11px", "13px", "15px"]},
     {"name": "paramX", "value":10, "range": [-20, 20]},
     {"name": "C_cut", "value": 1, "range": [0, 1]},
-    {"name": "CustomFunc", "value":"return Math.sin(A_mul_paramX_plus_B)"}
+    {"name": "CustomFunc", "value":"return Math.sin(A_mul_paramX_plus_B)"},
+    {"name": "predictors", "value":["A","A_mul_paramX_plus_B"], "options":["A", "A_mul_paramX_plus_B", "B", "C"]}
 ]
 
 # This interface with two arrays is only for the case when functions are reused with different columns as target
@@ -37,7 +38,7 @@ jsFunctionArray = [
     {
         "name": "linearFit",
         "type": "linearFit",
-        "varX": ["A_mul_paramX_plus_B", "C"],
+        "varX": "predictors",
         "varY": "B"
     }
 ]
@@ -71,7 +72,7 @@ aliasArray = [
     },
     {
         "name": "BPred",
-        "variables": ["A_mul_paramX_plus_B", "C"],
+        "variables": "predictors",
         "transform": "linearFit"
     }
 ]
@@ -119,13 +120,14 @@ widgetParams=[
     ['select',["legendFontSize"]],
     ['slider',["C_cut"]],
     ['slider',["paramX"]],
+    ['multiSelect', ["predictors"]],
     ['text', ["CustomFunc"], {"name": "CustomFunc"}]
 ]
 
 widgetLayoutDesc={
     "Selection": [[0, 1, 2], [3, 4], {'sizing_mode': 'scale_width'}],
     "Graphics": [[5, 6], {'sizing_mode': 'scale_width'}],
-    "CustomJS functions": [[7, 8],["CustomFunc"]]
+    "CustomJS functions": [[7, 8, 9],["CustomFunc"]]
     }
 
 figureLayoutDesc=[
@@ -169,10 +171,9 @@ def test_customJsFunctionBokehDrawArray_v():
             "parameters": ["paramX"],
             "fields": ["a", "b"],
             "v_func": """
-                if($output == null){
+                if($output == null || $output.length !== a.length){
                     $output = new Float64Array(a.length)
                 }
-                if($output.length != a.length) $output.length = a.length
                 for(let i=0; i<$output.length; i++){
                     $output[i] = paramX*a[i]+b[i]
                 }

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -24,7 +24,7 @@ parameterArray = [
     {"name": "paramX", "value":10, "range": [-20, 20]},
     {"name": "C_cut", "value": 1, "range": [0, 1]},
     {"name": "CustomFunc", "value":"return Math.sin(A_mul_paramX_plus_B)"},
-    {"name": "predictors", "value":["A","A_mul_paramX_plus_B"], "options":["A", "A_mul_paramX_plus_B", "B", "C"]}
+    {"name": "predictors", "value":["A","A_mul_paramX_plus_B"], "options":["A", "A_mul_paramX_plus_B", "B", "C", "custom_column"]}
 ]
 
 # This interface with two arrays is only for the case when functions are reused with different columns as target
@@ -39,7 +39,7 @@ jsFunctionArray = [
         "name": "linearFit",
         "type": "linearFit",
         "varX": "predictors",
-        "varY": "B"
+        "varY": "A_mul_paramX_plus_B"
     }
 ]
 

--- a/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_Alias.py
@@ -206,4 +206,3 @@ def test_makeColumns():
     print(sources)
     print(aliasDict)
 
-test_customJsFunctionBokehDrawArray_v()

--- a/RootInteractive/InteractiveDrawing/bokeh/test_ClientSideJoin.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_ClientSideJoin.py
@@ -49,4 +49,3 @@ def test_join():
     output_file("test_join_inner.html")
     bokehDrawSA.fromArray(df, None, figureArray, widgetParams, sourceArray=sourceArray, layout=figureLayout, widgetLayout=widgetDesc)
 
-test_join()

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -66,7 +66,7 @@ def predictRFStatTrivial(rf, X, statDictionary, n_jobs):
         statOut["std"] = np.sqrt(rfSumSq) 
     return statOut
 
-def predictRFStatChunk(rf, X, statDictionary, parallel):
+def predictRFStatChunk(rf, X, statDictionary, parallel, n_jobs):
     """
     inspired by https://github.com/scikit-learn/scikit-learn/blob/37ac6788c/sklearn/ensemble/_forest.py#L1410
     predict statistics from random forest
@@ -132,11 +132,12 @@ def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=1000000):
     :param X:                   input vector
     :param statDictionary:      dictionary of statistics to predict
     :param n_jobs:              number of parallel jobs for prediction
+    :param max_rows:
     :return:                    dictionary with requested output statistics
     """
     if(max_rows < 0):
        with Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem") as parallel:
-           return predictRFStatChunk(rf, X, statDictionary, parallel)
+           return predictRFStatChunk(rf, X, statDictionary, parallel, n_jobs)
     is_trivial = True
     for key in statDictionary.keys():
         if key not in ["mean", "std"]:
@@ -149,7 +150,7 @@ def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=1000000):
     answers = []
     with Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem") as parallel:
         for (a,b) in zip(block_begin, block_end):
-             answers.append(predictRFStatChunk(rf, X[a:b], statDictionary, parallel))
+             answers.append(predictRFStatChunk(rf, X[a:b], statDictionary, parallel, n_jobs))
     if not answers:
         return {}
     merged = {}

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -40,15 +40,6 @@ def _accumulate_predictionNL(predict, X, out,col):
 def simple_predict(predict, X, out, col):
     out[col] = predict(X, check_input=False)
 
-def partitionBlock(allRF, k, begin, end):
-    allRF[begin:end].partition(k)
-
-def blockMean(allRF, out, begin, end):
-    np.mean(allRF[begin:end], -1, out=out[begin:end])
-
-def blockStd(allRF, out, begin, end):
-    np.std(allRF[begin:end], -1, out=out[begin:end])
-
 def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     """
     inspired by https://github.com/scikit-learn/scikit-learn/blob/37ac6788c/sklearn/ensemble/_forest.py#L1410
@@ -74,21 +65,21 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     block_end.append(X.shape[0])
     if "median" in statDictionary:
         Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-                delayed(partitionBlock)(allRFTranspose, nEstimators // 2, first, last)
+                delayed(allRF[first:last].partition)(nEstimators // 2)
                 for first, last in zip(block_begin, block_end)
                 )
         statOut["median"]= allRFTranspose[:,nEstimators//2]
     if "mean"  in statDictionary:
         mean_out = np.empty(X.shape[0])
         Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-                delayed(blockMean)(allRFTranspose, mean_out, first, last)
+                delayed(np.mean)(allRFTranspose[first:last], -1, out=mean_out[first:last])
                 for first, last in zip(block_begin, block_end)
                 )
         statOut["mean"]=mean_out
     if "std"  in statDictionary: 
         std_out = np.empty(X.shape[0])
         Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-                delayed(blockStd)(allRFTranspose, std_out, first, last)
+                delayed(blockStd)(allRFTranspose[first:last], -1, out=std_out[first:last])
                 for first, last in zip(block_begin, block_end)
                 )
         statOut["std"]=std_out
@@ -96,7 +87,7 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
         statOut["quantile"]={}
         quantiles = np.array(statDictionary["quantile"]) * nEstimators
         Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-            delayed(partitionBlock)(allRFTranspose, quantiles, first, last)
+                delayed(allRF[first:last].partition)(quantiles)
             for first, last in zip(block_begin, block_end)
         )
         for iQuant, quant in enumerate(statDictionary["quantile"]):

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -37,8 +37,34 @@ def _accumulate_predictionNL(predict, X, out,col):
     prediction = predict(X, check_input=False)
     out[col] += prediction
 
+def _predict_accumulate_square(predict, X, out, outSq, lock):
+    prediction = predict(X, check_input=False)
+    predictionSq = prediction*prediction
+    with lock:
+        out += prediction
+        outSq += predictionSq
+
 def simple_predict(predict, X, out, col):
     out[col] = predict(X, check_input=False)
+
+def predictRFStatTrivial(rf, X, statDictionary, n_jobs):
+    nEstimators = len(rf.estimators_)
+    rfSum = np.zeros(X.shape[0])
+    rfSumSq = np.zeros(X.shape[0])
+    statOut = {}
+    lock = threading.Lock()
+    Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
+            delayed(_predict_accumulate_square)(e.predict, X, rfSum, rfSumSq, lock) for e in rf.estimators_
+            )
+    rfSum /= nEstimators
+    if "mean" in statDictionary:
+        statOut["mean"] = rfSum
+    if "std" in statDictionary:
+        # Somehow apply stream fusion?
+        rfSumSq /= nEstimators
+        rfSumSq -= rfSum*rfSum
+        statOut["std"] = np.sqrt(rfSumSq) 
+    return statOut
 
 def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     """
@@ -79,7 +105,7 @@ def predictRFStatChunk(rf, X, statDictionary,n_jobs):
     if "std"  in statDictionary: 
         std_out = np.empty(X.shape[0])
         Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-                delayed(blockStd)(allRFTranspose[first:last], -1, out=std_out[first:last])
+                delayed(np.std)(allRFTranspose[first:last], -1, out=std_out[first:last])
                 for first, last in zip(block_begin, block_end)
                 )
         statOut["std"]=std_out
@@ -110,6 +136,12 @@ def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=1000000):
     """
     if(max_rows < 0):
         return predictRFStatChunk(rf, X, statDictionary, n_jobs)
+    is_trivial = True
+    for key in statDictionary.keys():
+        if key not in ["mean", "std"]:
+            is_trivial = False
+    if is_trivial:
+        return predictRFStatTrivial(rf, X, statDictionary, n_jobs)
     block_begin = list(range(0, X.shape[0], max_rows))
     block_end = block_begin[1:]
     block_end.append(X.shape[0])    

--- a/RootInteractive/MLpipeline/MIForestErrPDF.py
+++ b/RootInteractive/MLpipeline/MIForestErrPDF.py
@@ -37,34 +37,8 @@ def _accumulate_predictionNL(predict, X, out,col):
     prediction = predict(X, check_input=False)
     out[col] += prediction
 
-def _predict_accumulate_square(predict, X, out, outSq, lock):
-    prediction = predict(X, check_input=False)
-    predictionSq = prediction*prediction
-    with lock:
-        out += prediction
-        outSq += predictionSq
-
 def simple_predict(predict, X, out, col):
     out[col] = predict(X, check_input=False)
-
-def predictRFStatTrivial(rf, X, statDictionary, n_jobs):
-    nEstimators = len(rf.estimators_)
-    rfSum = np.zeros(X.shape[0])
-    rfSumSq = np.zeros(X.shape[0])
-    statOut = {}
-    lock = threading.Lock()
-    Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem")(
-            delayed(_predict_accumulate_square)(e.predict, X, rfSum, rfSumSq, lock) for e in rf.estimators_
-            )
-    rfSum /= nEstimators
-    if "mean" in statDictionary:
-        statOut["mean"] = rfSum
-    if "std" in statDictionary:
-        # Somehow apply stream fusion?
-        rfSumSq /= nEstimators
-        rfSumSq -= rfSum*rfSum
-        statOut["std"] = np.sqrt(rfSumSq) 
-    return statOut
 
 def predictRFStatChunk(rf, X, statDictionary, parallel, n_jobs):
     """
@@ -113,7 +87,7 @@ def predictRFStatChunk(rf, X, statDictionary, parallel, n_jobs):
         statOut["quantile"]={}
         quantiles = np.array(statDictionary["quantile"]) * nEstimators
         parallel(
-                delayed(allRF[first:last].partition)(quantiles)
+            delayed(allRF[first:last].partition)(quantiles)
             for first, last in zip(block_begin, block_end)
         )
         for iQuant, quant in enumerate(statDictionary["quantile"]):
@@ -138,12 +112,6 @@ def predictRFStat(rf, X, statDictionary,n_jobs, max_rows=1000000):
     if(max_rows < 0):
        with Parallel(n_jobs=n_jobs, verbose=rf.verbose, require="sharedmem") as parallel:
            return predictRFStatChunk(rf, X, statDictionary, parallel, n_jobs)
-    is_trivial = True
-    for key in statDictionary.keys():
-        if key not in ["mean", "std"]:
-            is_trivial = False
-    if is_trivial:
-        return predictRFStatTrivial(rf, X, statDictionary, n_jobs)
     block_begin = list(range(0, X.shape[0], max_rows))
     block_end = block_begin[1:]
     block_end.append(X.shape[0])    


### PR DESCRIPTION
This PR adds linear regression on the client to RootInteractive.

This PR also:
- Enables using multiselect for parameters
- Fixes an infinite loop in javascript in case of cyclic dependency between custom defined columns

This isn't finished, and some features are missing:
- fitterArray to automatically create aliases, without having to use transformArray and aliasArray

How to use
```Python3
parameterArray = [
    {"name": "predictors", "value":["X1","X2"], "options":["X1", "X2", "X3",  "Custom"]}
]
jsFunctionArray = [
    {
        "name": "fitterY",
        "type": "linearFit",
        "varX": "predictors",
        "varY": "Y",
        "alpha": 1,
       "weights":"W",
       "source": None # If using the main source for fitting, this is optional
    }
]
aliasArray = [
    {
        "name": "YPred",
        "variables": "predictors",
        "transform": "fitterY"
    }
]
widgetParams=[
    ['multiSelect', ["predictors"]]
]
```

EDIT: Ridge regression and weights are working now