### PR TITLE
Multiselect varY / varYNorm template

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -50,7 +50,7 @@ export class CDSAlias extends ColumnarDataSource {
     this.connect(this.source.change, () => {this.cached_columns.clear(); this.change.emit()})
     for( const key in this.mapping){
       const column = this.mapping[key]
-      if(column.hasOwnProperty("transform")){
+      if(column != null && column.hasOwnProperty("transform")){
         this.connect(column.transform.change, () => {
           this.invalidate_column(key)
         })

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -72,7 +72,7 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
                 multiAxis = iVar
             else:
                 raise NotImplementedError("Multiple multiselect axes not implemented")
-        if iVar == multiAxis and isinstance(defaultValue, str):
+        if iVar == multiAxis and not isinstance(defaultValue, list):
             defaultValue = [defaultValue]
         parameterArray.append({"name": iVar, "value": defaultValue, "options":weights if iVar == "weights" else variables}) 
         widgetParams.append(['multiSelect' if iVar == multiAxis else 'select', [iVar], {"name":iVar}])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -96,6 +96,18 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
     figureGlobalOption["y_transform"]="yAxisTransform"
     figureGlobalOption["z_transform"]="zAxisTransform"
 
+    formulaYNorm = {
+            "diff":"varY-varYNorm",
+            "ratio":"varY/varYNorm",
+            "logRatio":"log(varY)/log(varYNorm)"
+            }[normalization]
+    
+    formulaZNorm = {
+            "diff":"varZ-varZNorm",
+            "ratio":"varZ/varZNorm",
+            "logRatio":"log(varZ)/log(varZNorm)"
+            }[normalization]
+
     histoArray=[
         {
             "name": "histoXYData",
@@ -111,44 +123,23 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
         },
     ]
 
-    if normalization in {"diff", "-"}:
+    if normalization is not None:
         histoArray.extend([
         {
             "name": "histoXYNormData",
-            "variables": ["varX","varY-varYNorm"],
+            "variables": ["varX",formulaYNorm],
             "weights": "weights" if weights else defaultWeights,
             "nbins":["nbinsX","nbinsY"], "axis":[1],"quantiles": [0.35,0.5],"unbinned_projections":True,
         },
         {
             "name": "histoXYNormZData",
-            "variables": ["varX","varY-varYNorm","varZ"],
+            "variables": ["varX",formulaYNorm,"varZ"],
             "weights": "weights" if weights else defaultWeights,
             "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
         },
         {
             "name": "histoXYZNormData",
-            "variables": ["varX","varY","varZ-varZNorm"],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        ])
-    elif normalization in {"ratio", "/"}:
-        histoArray.extend([
-        {
-            "name": "histoXYNormData",
-            "variables": ["varX","varY/varYNorm"],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY"], "axis":[1],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        {
-            "name": "histoXYNormZData",
-            "variables": ["varX","varY/varYNorm","varZ"],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        {
-            "name": "histoXYZNormData",
-            "variables": ["varX","varY","varZ/varZNorm"],
+            "variables": ["varX","varY",formulaZNorm],
             "weights": "weights" if weights else defaultWeights,
             "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
         },
@@ -157,7 +148,7 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
     yAxisTitleNorm = {
             "diff":"{varY}-{varYNorm}",
             "ratio":"{varY}/{varYNorm}",
-            "logRatio":"log(varY)/log(varYNorm)"
+            "logRatio":"log({varY})/log({varYNorm})"
             }[normalization]
 
     figureArray=[

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -209,6 +209,6 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
 def getDefaultVarsDiff(*args, **kwargs):
     return getDefaultVars("diff", *args, **kwargs)
 
-def getDefaultVarsRatio():
+def getDefaultVarsRatio(*args, **kwargs):
     return getDefaultVars("ratio", *args, **kwargs)
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -65,16 +65,16 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
     # histogram selection
     for i, iVar in enumerate(parameterVars):
         defaultValue = defaultVariables.get(iVar, variables[i % len(variables)])
+        if iVar == "weights":
+            defaultValue = defaultVariables.get("weights", weights[0])
         if iVar == multiAxis and isinstance(defaultValue, str):
             defaultValue = [defaultValue]
-        parameterArray.append({"name": iVar, "value": defaultValue, "options":variables}) 
+        parameterArray.append({"name": iVar, "value": defaultValue, "options":weights if iVar == "weights" else variables}) 
         widgetParams.append(['multiSelect' if iVar == multiAxis else 'select', [iVar], {"name":iVar}])
 
     defaultWeights=None
     if isinstance(weights, list):
         defaultWeights = defaultVariables.get("weights", weights[0])
-        parameterArray.append({"name": "weights", "value": defaultWeights, "options":weights}) 
-        widgetParams.append(['select', ['weights'], {"name":"weights"}])
 
     widgetParams.extend(figureParameters["legend"]["widgets"])
     widgetParams.extend(figureParameters["markers"]["widgets"])

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -84,7 +84,6 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
     widgetParams.extend(figureParameters["legend"]["widgets"])
     widgetParams.extend(figureParameters["markers"]["widgets"])
 
-
     widgetLayoutDesc={
         "Select": [],
         "Custom":[["customSelect0","customSelect1","customSelect2"],["funCustomForm0","funCustomForm1","funCustomForm2"]],
@@ -118,37 +117,116 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
             "name": "histoXYData",
             "variables": ["varX","varY"],
             "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY"], "axis":[1],"quantiles": [0.35,0.5],"unbinned_projections":True,
+            "nbins":["nbinsX","nbinsY"], "quantiles": [0.35,0.5],"unbinned_projections":True,
         },
         {
             "name": "histoXYZData",
             "variables": ["varX","varY","varZ"],
             "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
+            "nbins":["nbinsX","nbinsY","nbinsZ"], "quantiles": [0.35,0.5],"unbinned_projections":True,
         },
     ]
 
     if normalization is not None:
-        histoArray.extend([
-        {
-            "name": "histoXYNormData",
-            "variables": ["varX",formulaYNorm],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY"], "axis":[1],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        {
-            "name": "histoXYNormZData",
-            "variables": ["varX",formulaYNorm,"varZ"],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        {
-            "name": "histoXYZNormData",
-            "variables": ["varX","varY",formulaZNorm],
-            "weights": "weights" if weights else defaultWeights,
-            "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
-        },
-        ])
+        if multiAxis in ["varY", "varYNorm"]:
+            histoXYNames = {i:f"histoXYNormData[{i}]" for i in variables}
+            histoXY1Names = {i:f"histoXYNormData_1[{i}]" for i in variables}
+            histoXYZNames = {i:f"histoXYNormZData[{i}]" for i in variables}
+            histoXYZ1Names = {i:f"histoXYNormZData_1[{i}]" for i in variables}
+            histoXYZ2Names = {i:f"histoXYNormZData_1[{i}]" for i in variables}
+            varNorm = {
+                "diff": lambda x,y: f"{x}-{y}",
+                "ratio": lambda x,y: f"{x}/{y}",
+                "logRatio":lambda x,y: f"log({x})/log({y})"
+            }[normalization]
+            histoArray.extend([{
+                "name": f"histoXYNormData[{i}]",
+                "variables": ["varX", varNorm(i, "varYNorm") if multiAxis == "varY" else varNorm("varY", i)],
+                "weights": "weights" if weights else defaultWeights,   
+                "nbins": ["nbinsX", "nbinsY"]        
+            } for i in variables])
+            histoArray.extend([{
+                "name": f"histoXYNormData_1[{i}]",
+                "type": "projection",
+                "source": f"histoXYNormData[{i}]",
+                "axis_idx": 1,
+                "weights": "weights" if weights else defaultWeights,
+                "quantiles": [0.35,0.5],"unbinned":True,                
+            } for i in variables])
+            histoArray.extend([{
+                "name": f"histoXYNormZData[{i}]",
+                "variables": ["varX", varNorm(i, "varYNorm") if multiAxis == "varY" else varNorm("varY", i), "varZ"],
+                "weights": "weights" if weights else defaultWeights,
+                "nbins":["nbinsX","nbinsY", "nbinsZ"],                
+            } for i in variables])
+            histoArray.extend([{
+                "name": f"histoXYNormZData_1[{i}]",
+                "type": "projection",
+                "source": f"histoXYNormZData[{i}]",
+                "axis_idx": 1,
+                "weights": "weights" if weights else defaultWeights,
+                "quantiles": [0.35,0.5],"unbinned":True,                
+            } for i in variables])
+            histoArray.extend([{
+                "name": f"histoXYNormZData_2[{i}]",
+                "type": "projection",
+                "source": f"histoXYNormZData[{i}]",
+                "axis_idx": 2,
+                "weights": "weights" if weights else defaultWeights,
+                "quantiles": [0.35,0.5],"unbinned":True,                
+            } for i in variables])
+            histoArray.extend([
+            {
+                "name": "histoXYNormData",
+                "sources": multiAxis,
+                "mapping": histoXYNames
+            },
+            {
+                "name": "histoXYNormData_1",
+                "sources": multiAxis,
+                "mapping": histoXY1Names
+            },
+            {
+                "name": "histoXYNormZData",
+                "sources": multiAxis,
+                "mapping": histoXYZNames
+            },
+            {
+                "name": "histoXYNormZData_1",
+                "sources": multiAxis,
+                "mapping": histoXYZ1Names
+            },
+            {
+                "name": "histoXYNormZData_2",
+                "sources": multiAxis,
+                "mapping": histoXYZ2Names
+            }
+            ])
+        else:
+            histoArray.extend([
+            {
+                "name": "histoXYNormData",
+                "variables": ["varX",formulaYNorm],
+                "weights": "weights" if weights else defaultWeights,
+                "nbins":["nbinsX","nbinsY"], "axis":[1],"quantiles": [0.35,0.5],"unbinned_projections":True,
+            },
+            {
+                "name": "histoXYNormZData",
+                "variables": ["varX",formulaYNorm,"varZ"],
+                "weights": "weights" if weights else defaultWeights,
+                "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
+            },
+            ])
+        if multiAxis in ["varZ", "varZNorm"]:
+            pass
+        else:
+            histoArray.append(            
+                {
+                    "name": "histoXYZNormData",
+                    "variables": ["varX","varY",formulaZNorm],
+                    "weights": "weights" if weights else defaultWeights,
+                    "nbins":["nbinsX","nbinsY","nbinsZ"], "axis":[1,2],"quantiles": [0.35,0.5],"unbinned_projections":True,
+                })
 
     yAxisTitleNorm = {
             "diff":"{varY}-{varYNorm}",
@@ -163,10 +241,10 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
         [["bin_center_0"], ["mean","quantile_1",], { "source":"histoXYData_1","errY":"std/sqrt(entries)"}],
         [["bin_center_0"], ["std"], { "source":"histoXYData_1","errY":"std/sqrt(entries)"}],
         # histoXYNorm
-        [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "bin_count", "source":"histoXYNormData"}],
-        [["bin_center_1"], ["bin_count"], { "source":"histoXYNormData", "colorZvar": "bin_center_0"}],
-        [["bin_center_0"], ["mean","quantile_1",], { "source":"histoXYNormData_1","errY":"std/sqrt(entries)"}],
-        [["bin_center_0"], ["std"], { "source":"histoXYNormData_1","errY":"std/sqrt(entries)"}],
+        [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "bin_count", "source":"histoXYNormData","yAxisTitle":yAxisTitleNorm}],
+        [["bin_center_1"], ["bin_count"], { "source":"histoXYNormData", "colorZvar": "bin_center_0","yAxisTitle":yAxisTitleNorm}],
+        [["bin_center_0"], ["mean","quantile_1",], { "source":"histoXYNormData_1","errY":"std/sqrt(entries)","yAxisTitle":yAxisTitleNorm}],
+        [["bin_center_0"], ["std"], { "source":"histoXYNormData_1","errY":"std/sqrt(entries)","yAxisTitle":yAxisTitleNorm}],
         # histoXYZ
         [["bin_center_0"], ["mean"], { "source":"histoXYZData_1","colorZvar":"bin_center_2","errY":"std/sqrt(entries)"}],
         [["bin_center_0"], ["entries"], { "source":"histoXYZData_1","colorZvar":"bin_center_2","errY":"2*std/sqrt(entries)"}],
@@ -177,10 +255,10 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
         [["bin_center_0"], ["entries"], { "source":"histoXYNormZData_1","colorZvar":"bin_center_2","errY":"2*std/sqrt(entries)","yAxisTitle":yAxisTitleNorm}],
         [["bin_center_0"], ["quantile_1"], { "source":"histoXYNormZData_1","colorZvar":"bin_center_2","errY":"3*std/sqrt(entries)","yAxisTitle":yAxisTitleNorm}],
         [["bin_center_0"], ["std"], { "source":"histoXYNormZData_1","colorZvar":"bin_center_2","errY":"std/sqrt(entries)","yAxisTitle":yAxisTitleNorm}],
-        # histoXYNormZMedian
+        # histoXYZNormMedian
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "quantile_1", "source":"histoXYZData_2"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "quantile_1", "source":"histoXYZNormData_2"}],
-        # histoXYNormZMean
+        # histoXYZNormMean
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "mean", "source":"histoXYZData_2"}],
         [[("bin_bottom_0", "bin_top_0")], [("bin_bottom_1", "bin_top_1")], {"colorZvar": "mean", "source":"histoXYZNormData_2"}],
         #

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -67,6 +67,11 @@ def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weig
         defaultValue = defaultVariables.get(iVar, variables[i % len(variables)])
         if iVar == "weights":
             defaultValue = defaultVariables.get("weights", weights[0])
+        if isinstance(defaultValue, list):
+            if multiAxis is None:
+                multiAxis = iVar
+            else:
+                raise NotImplementedError("Multiple multiselect axes not implemented")
         if iVar == multiAxis and isinstance(defaultValue, str):
             defaultValue = [defaultValue]
         parameterArray.append({"name": iVar, "value": defaultValue, "options":weights if iVar == "weights" else variables}) 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1912,7 +1912,6 @@ def getOrMakeCdsOrig(cdsDict: dict, paramDict: dict, key: str):
             multi_axis = None
             weights = iCds.get("weights", None)
             sample_variables = iCds["variables"]
-            name_orig = f"{cdsName}_orig"
             source = getOrMakeCdsFull(cdsDict, paramDict, iCds.get("source", None))
             if "source" not in iCds:
                 iCds["source"] = None
@@ -1942,7 +1941,7 @@ def getOrMakeCdsOrig(cdsDict: dict, paramDict: dict, key: str):
                         else:
                             multi_axis = ("variables", i)
             if multi_axis is None:
-                cdsOrig = HistoNdCDS(source=source, sample_variables=sample_value, weights=weights, name=cdsName, nbins=nbins_value, range=range_value)
+                cdsOrig = HistoNdCDS(source=source, sample_variables=sample_value, weights=weights_value, name=cdsName, nbins=nbins_value, range=range_value)
                 iCds["cdsOrig"] = cdsOrig
                 histogramsLocal = [cdsOrig]
             else:

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1746,9 +1746,8 @@ def getHistogramAxisTitle(cdsDict, varName, cdsName, removeCdsName=True):
                 if cdsDict[cdsName]["type"] == "projection":
                     cdsOrig = cdsDict[cdsName]["cdsOrig"]
                     cdsOrig = cdsOrig if isinstance(cdsOrig, HistoNdProfile) else cdsOrig.sources[0]
-                    histogramOrig = cdsOrig.source
                     projectionIdx = cdsOrig.axis_idx
-                    return f"quantile {quantile} {{{ histogramOrig.sample_variables[projectionIdx] }}}"
+                    return f"quantile {quantile} {{{cdsDict[cdsDict[cdsName]['source']]['variables'][projectionIdx] }}}"
                 return f"quantile {{{quantile}}}"
             if x[0] == "sum":
                 range = cdsDict[cdsName]["sum_range"][int(x[-1])]
@@ -1756,27 +1755,22 @@ def getHistogramAxisTitle(cdsDict, varName, cdsName, removeCdsName=True):
                     if cdsDict[cdsName]["type"] == "projection":
                         cdsOrig = cdsDict[cdsName]["cdsOrig"]
                         cdsOrig = cdsOrig if isinstance(cdsOrig, HistoNdProfile) else cdsOrig.sources[0]
-                        histogramOrig = cdsOrig.source
                         projectionIdx = cdsOrig.axis_idx
-                        return f"sum {{{histogramOrig.sample_variables[projectionIdx]}}} in [{range[0]}, {range[1]}]"
+                        return f"sum {{{cdsDict[cdsDict[cdsName]['source']]['variables'][projectionIdx]}}} in [{range[0]}, {range[1]}]"
                     return f"sum in [{range[0]}, {range[1]}]"
                 elif len(x) == 3:
                     if cdsDict[cdsName]["type"] == "projection":
                         cdsOrig = cdsDict[cdsName]["cdsOrig"]
                         cdsOrig = cdsOrig if isinstance(cdsOrig, HistoNdProfile) else cdsOrig.sources[0]
-                        histogramOrig = cdsOrig.source
                         projectionIdx = cdsOrig.axis_idx
-                        return f"p {{{histogramOrig.sample_variables[projectionIdx]}}} in [{range[0]}, {range[1]}]"
+                        return f"p {{{cdsDict[cdsDict[cdsName]['source']]['variables'][projectionIdx]}}} in [{range[0]}, {range[1]}]"
                     return f"p in [{range[0]}, {range[1]}]"
         else:
             if cdsDict[cdsName]["type"] == "projection":
                 cdsOrig = cdsDict[cdsName]["cdsOrig"]
-                if isinstance(cdsOrig, HistoNdProfile):
-                    histogramOrig = cdsDict[cdsName]["cdsOrig"].source
-                    projectionIdx = cdsDict[cdsName]["cdsOrig"].axis_idx
-                    return f"{varName} {{{histogramOrig.sample_variables[projectionIdx]}}}"
-                else:
-                    return f"{varName}"
+                cdsOrig = cdsOrig if isinstance(cdsOrig, HistoNdProfile) else cdsOrig.sources[0]
+                projectionIdx = cdsOrig.axis_idx
+                return f"{varName} {{{cdsDict[cdsDict[cdsName]['source']]['variables'][projectionIdx]}}}"
     return prefix+varName
 
 def makeCDSDict(sourceArray, paramDict, options={}):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1510,8 +1510,8 @@ def makeBokehMultiSelectWidget(df: pd.DataFrame, params: list, paramDict: dict, 
     options.update(kwargs)
     # optionsPlot = []
     if options['callback'] == 'parameter':
-        optionsPlot = paramDict[params[0]]["options"]
-        optionsSelected = paramDict[params[0]]["value"]
+        optionsPlot = [str(i) for i in paramDict[params[0]]["options"]]
+        optionsSelected = [str(i) for i in paramDict[params[0]]["value"]]
     else:
         if len(params) > 1:
             dfCategorical = df[params[0]].astype(pd.CategoricalDtype(ordered=True, categories=params[1:]))
@@ -1958,7 +1958,7 @@ def getOrMakeCdsOrig(cdsDict: dict, paramDict: dict, key: str):
                         sample_value[multi_axis[1]] = i
                     cdsOrig = HistoNdCDS(source=source, sample_variables=sample_value.copy(), weights=weights_value, name=f"{cdsName}[{i}]", nbins=nbins_value, range=range_value)
                     histogramsLocal.append(cdsOrig)
-                cdsOrig = CDSStack(sources=histogramsLocal, activeSources=paramDict[acc]["value"], mapping={value:i for (i, value) in enumerate(histoOptions)})
+                cdsOrig = CDSStack(sources=histogramsLocal, activeSources=[str(i) for i in paramDict[acc]["value"]], mapping={str(value):i for (i, value) in enumerate(histoOptions)})
                 iCds["cdsOrig"] = cdsOrig
                 paramDict[acc]["subscribed_events"].append(["value", cdsOrig, "activeSources"])
             for binsIdx, iBins in enumerate(nbins):

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -1067,7 +1067,7 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
                 if 'tooltips' in optionLocal and cds_names[i] is None:
                     tooltipColumns = getTooltipColumns(optionLocal['tooltips'])
                 else:
-                    tooltipColumns = getTooltipColumns(cdsDict[cds_name]["tooltips"])
+                    tooltipColumns = getTooltipColumns(cdsDict[cds_name].get("tooltips", []))
                 _, _, memoized_columns, tooltip_sources = getOrMakeColumns(list(tooltipColumns), cds_names[i], cdsDict, paramDict, jsFunctionDict, memoized_columns, aliasDict)
                 sources.update(tooltip_sources)
             if cds_name == "$IGNORE":
@@ -1101,7 +1101,8 @@ def bokehDrawArray(dataFrame, query, figureArray, histogramArray=[], parameterAr
         if color_bar is not None:
             figureI.add_layout(color_bar, 'right')
         for iCds, iRenderers in hover_tool_renderers.items():
-            figureI.add_tools(HoverTool(tooltips=cdsDict[iCds]["tooltips"], renderers=iRenderers))
+            if cdsDict[iCds].get("tooltips", None) is not None:
+                figureI.add_tools(HoverTool(tooltips=cdsDict[iCds]["tooltips"], renderers=iRenderers))
         if figureI.legend:
             figureI.legend.click_policy = "hide"
             if optionLocal["legendTitle"] is not None:

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -1,7 +1,7 @@
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
 from RootInteractive.Tools.aliTreePlayer import *
 from RootInteractive.InteractiveDrawing.bokeh.bokehTools import mergeFigureArrays
-from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveTemplate import getDefaultVarsDiff
+from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveTemplate import getDefaultVarsDiff, getDefaultVarsRatio
 from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveParameters import figureParameters
 from RootInteractive.Tools.compressArray import arrayCompressionRelative16
 from pandas import CategoricalDtype
@@ -373,7 +373,7 @@ def test_StableQuantile():
 
 def test_interactiveTemplateWeights():
     output_file("test_histogramTemplate.html")
-    aliasArray, variables, parameterArray, widgetParams, widgetLayoutDesc, histoArray, figureArray, figureLayoutDesc = getDefaultVarsDiff(variables=["A", "B", "C", "D", "A*A", "A*A+B", "B/(1+C)"], weights=["A>.5", "B>C"])
+    aliasArray, variables, parameterArray, widgetParams, widgetLayoutDesc, histoArray, figureArray, figureLayoutDesc = getDefaultVarsDiff(variables=["A", "B", "C", "D", "A*A", "A*A+B", "B/(1+C)"], weights=[None, "A>.5", "B>C"], multiAxis="weights")
     parameterArray = parameterArray + [
                 {"name":"varXMulti", "value":["A", "B"], "options":variables},
                 {"name":"varYMulti", "value":["A", "B"], "options":variables}
@@ -411,5 +411,19 @@ def test_interactiveTemplateWeights():
     figureLayoutDesc["Histo1D"] = [["histo1D", "histo1DMulti"], {"plot_height":350}]
     figureLayoutDesc["HistoMultiX"] = [["histoNDMultiX_1_Mean", "histoNDMultiX_1_Median"], ["histoNDMultiX_0_Mean", "histoNDMultiX_0_Median"], {"plot_height":240}]
     figureLayoutDesc["HistoMultiY"] = [["histoNDMultiY_1_Mean", "histoNDMultiY_1_Median"], ["histoNDMultiY_0_Mean", "histoNDMultiY_0_Median"], {"plot_height":240}]
+    bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, parameterArray=parameterArray,
+                          widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray, aliasArray=aliasArray, arrayCompression=arrayCompressionRelative16)
+
+def test_interactiveTemplateMultiX():
+    output_file("test_histogramTemplateMultiX.html")
+    aliasArray, variables, parameterArray, widgetParams, widgetLayoutDesc, histoArray, figureArray, figureLayoutDesc = getDefaultVarsRatio(variables=["A", "B", "C", "D", "A*A", "A*A+B", "B/(1+C)"], defaultVariables={"varX":["A"]})
+    widgetsSelect = [
+        ['range', ['A'], {"name":"A"}],
+        ['range', ['B'], {"name":"B"}],
+        ['range', ['C'], {"name":"C"}],
+        ['range', ['D'], {"name":"D"}],
+        ]
+    widgetParams = mergeFigureArrays(widgetParams, widgetsSelect)
+    widgetLayoutDesc["Select"] = [["A","B"],["C","D"]]
     bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, parameterArray=parameterArray,
                           widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray, aliasArray=aliasArray, arrayCompression=arrayCompressionRelative16)

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -427,3 +427,18 @@ def test_interactiveTemplateMultiX():
     widgetLayoutDesc["Select"] = [["A","B"],["C","D"]]
     bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, parameterArray=parameterArray,
                           widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray, aliasArray=aliasArray, arrayCompression=arrayCompressionRelative16)
+    
+def test_interactiveTemplateMultiY():
+    output_file("test_histogramTemplateMultiY.html")
+    aliasArray, variables, parameterArray, widgetParams, widgetLayoutDesc, histoArray, figureArray, figureLayoutDesc = getDefaultVarsDiff(variables=["A", "B", "C", "D", "A*A", "A*A+B", "B/(1+C)"], defaultVariables={"varY":["B", "A*A+B"]})
+    widgetsSelect = [
+        ['range', ['A'], {"name":"A"}],
+        ['range', ['B'], {"name":"B"}],
+        ['range', ['C'], {"name":"C"}],
+        ['range', ['D'], {"name":"D"}],
+        ]
+    widgetParams = mergeFigureArrays(widgetParams, widgetsSelect)
+    widgetLayoutDesc["Select"] = [["A","B"],["C","D"]]
+    bokehDrawSA.fromArray(df, None, figureArray, widgetParams, layout=figureLayoutDesc, parameterArray=parameterArray,
+                          widgetLayout=widgetLayoutDesc, sizing_mode="scale_width", histogramArray=histoArray, aliasArray=aliasArray, arrayCompression=arrayCompressionRelative16)
+    


### PR DESCRIPTION
This PR adds multiselect varY / varYNorm for the getDefaultVars template

Because "varY-varYNorm" alias is not defined when one of these is a multiselect, it's done by creating multiple histograms and then creating the join, in the template

It also fixes a bug with the Y axis label introduced in #326, a bug making getDefaultVarsRatio also introduced in #326 not work because of a typo and an old bug with scalar histogram weights (possibly never worked properly)

Multiselect varZ / varZNorm not supported for template yet

Example use cases in test_bokehClientHistogram.py