### PR TITLE
Various client side lazy evaluation optimizations and bugfix

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CustomJSNAryFunction.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/CustomJSNAryFunction.py
@@ -6,6 +6,6 @@ class CustomJSNAryFunction(Model):
 
     parameters = Dict(String, Any, help="Extra arguments to call the function with")
     fields = List(String, default=[], help="List of positional arguments - might be made optional in the future")
-    func = String(serialized=True, help="Code to be computed on the client - scalar case")
-    v_func = String(serialized=True, help="Code to be computed on the client - vector case")
+    func = String(help="Code to be computed on the client - scalar case")
+    v_func = String(help="Code to be computed on the client - vector case")
 

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehInteractiveTemplate.py
@@ -2,6 +2,9 @@
 # from RootInteractive.Tools.compressArray import arrayCompressionRelative16, arrayCompressionRelative8
 # from bokeh.plotting import output_file
 from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveParameters import figureParameters 
+import re
+
+RE_VALID_JS_NAME = re.compile(r"^[a-zA-Z_$][0-9a-zA-Z_$]*$")
 
 def getDefaultVars(normalization=None, variables=None, defaultVariables={}, weights=None, multiAxis=None):
     """
@@ -290,7 +293,7 @@ def getDefaultVarsNormAll(variables=None, defaultVariables={}, weights=None, mul
     # defining custom javascript function to query  (used later in variable list)
     if variables is None:
         variables = []
-    variablesCopy = variables.copy()
+    variablesCopy = [i for i in variables if re.match(RE_VALID_JS_NAME, i)]
     aliasArray=[
         {"name": "funCustom0",  "func":"funCustomForm0", "variables":variablesCopy},
         {"name": "funCustom1",  "func":"funCustomForm1", "variables":variablesCopy},

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -13,7 +13,7 @@ from RootInteractive.Tools.aliTreePlayer import *
 from bokeh.layouts import *
 import logging
 from IPython import get_ipython
-from bokeh.models.widgets import Select, Slider, RangeSlider, MultiSelect, TableColumn, TextAreaInput, Toggle, Spinner
+from bokeh.models.widgets import Select, Slider, RangeSlider, MultiSelect, TableColumn, TextAreaInput, Toggle, Spinner, Panel
 from bokeh.models import CustomJS, ColumnDataSource
 from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJSGraph3D
 from RootInteractive.InteractiveDrawing.bokeh.HistogramCDS import HistogramCDS

--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -13,7 +13,7 @@ from RootInteractive.Tools.aliTreePlayer import *
 from bokeh.layouts import *
 import logging
 from IPython import get_ipython
-from bokeh.models.widgets import Select, Slider, RangeSlider, MultiSelect, Panel, TableColumn, TextAreaInput, Toggle, Spinner
+from bokeh.models.widgets import Select, Slider, RangeSlider, MultiSelect, TableColumn, TextAreaInput, Toggle, Spinner
 from bokeh.models import CustomJS, ColumnDataSource
 from RootInteractive.InteractiveDrawing.bokeh.bokehVisJS3DGraph import BokehVisJSGraph3D
 from RootInteractive.InteractiveDrawing.bokeh.HistogramCDS import HistogramCDS

--- a/RootInteractive/Tools/aliTreePlayer.py
+++ b/RootInteractive/Tools/aliTreePlayer.py
@@ -579,7 +579,7 @@ def LoadTrees(inputDataList, chRegExp, chNotReg, inputFileSelection, verbose):
         #      read metadata #tag:value information - signed by # at the beginning of the line
         for jFile in range(iFile, nFiles):  # get rid of the loop using continue
             name = residualMapList.At(jFile).GetName()
-            if name[0] is '#':
+            if name[0] == '#':
                 first = name.find(":")
                 tag = name[1:name.find(":")]
                 value = name[name.find(":") + 1:len(name)]
@@ -616,13 +616,13 @@ def LoadTrees(inputDataList, chRegExp, chNotReg, inputFileSelection, verbose):
             return None,None,None
         isLegend = False
         for iKey in range(keys.GetEntries()):
-            if regExp.Match(keys.At(iKey).GetName()) is 0:
+            if regExp.Match(keys.At(iKey).GetName()) == 0:
                 continue  # is selected
-            if notReg.Match(keys.At(iKey).GetName()) is not 0:
+            if notReg.Match(keys.At(iKey).GetName()) != 0:
                 continue  # is rejected
             tree = finput.Get(keys.At(iKey).GetName())  # better to use dynamic cast
             treeBaseList.append(tree)
-            if treeBase.GetEntries() is 0:
+            if treeBase.GetEntries() == 0:
                 finput2 = ROOT.TFile.Open(fileName, option)
                 fileList.append(finput2)
                 treeBase = finput2.Get(keys.At(iKey).GetName())


### PR DESCRIPTION
This PR:
- Fixes funCustom when using the template and specifying anonymous functions as variables, before it just crashed by parsing the input with a regex
- Optimizes lazy evaluation when selection formally changes but no actual change happens, at the cost of slightly slowing down evaluation otherwise (factor 4 speedup in usual use case)
- Optimizes swapping out a function used by multiple columns (factor 2 speedup when changing diff function in getDefaultVarsNormAll)
- Removes compute_functions() function as it's not used anywhere
- Fixes warnings in aliTreePlayer.py