### PR TITLE
Rolling window statistics - so far only sum, mean and std

### DIFF
--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -250,7 +250,7 @@ RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
 RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":
-            self.helpvar_stmt.append((0, f"""
+            self.helpervar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){{
     arr_{new_helper_id}[i] /= i;
 }};

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -231,7 +231,7 @@ class RDataFrame_Visit:
     def visit_Rolling(self, node: ast.Call):
         if len(node.args) < 2:
             raise TypeError(f"Got {len(node.args)} arguments, expected 2")
-        self.headers["RollingSum"] = "#include \"RollingSum.cpp\"\n"
+        self.headers["RollingSum"] = "#include \"$RootInteractive/RootInteractive/Tools/RDataFrame/RollingSum.cpp\"\n"
         arr = self.visit(node.args[0])
         arr_name = arr["implementation"]
         dtype = unpackScalarType(scalar_type_str(arr["type"]), 1)

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -268,7 +268,7 @@ RootInteractive::rolling_sum{''.join(qualifiers)}({arr_name}.begin(), {arr_name}
 for(size_t i=0; i<{arr_name}.size(); ++i){{
     arr_{new_helper_id}[i] /= 2*{width};
 }}
-                """)
+                """))
             else:
                 self.helpervar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){{

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -713,8 +713,8 @@ def makeDefineRNode(columnName, funName, parsed,  rdf, verbose=1, flag=0x1):
     # 0.) Define function if does not exist yet
 
     try:
-        ROOT.gSystem.AddIncludePath("-l$RootInteractive/")
-        ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
+        ROOT.gSystem.AddIncludePath(" -I$RootInteractive/")
+        #ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
         ROOT.gInterpreter.Declare( parsed["implementation"])
     except:
         logging.error(f'makeDefineRNode compilation of {funName} failed Implementation in {parsed["implemntation"]}')

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -253,7 +253,7 @@ class RDataFrame_Visit:
             new_arr_size = f"{arr_name}.size()"
             qualifiers.append("_weighted")
             time_arr=self.visit(keywords["time"])
-            if scalar_type(unpackScalarType(scalar_type_str(time_arr["type"]))[0] == 'o':
+            if scalar_type(unpackScalarType(scalar_type_str(time_arr["type"])))[0] == 'o':
                 raise TypeError("Weights array for rolling sum must be of numeric data type"
             time_arr_name = f", time_arr['implementation']"
         new_helper_id = self.helpervar_idx

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -574,7 +574,7 @@ for(size_t i={width}; i;--i){{
         array_type = f"ROOT::VecOps::RVec<{array_type}>"
         expr_f = f"result{depth_f_lower}[i{depth_f_lower}] = result{depth_f};" if depth>0 else ""
         return f"""
-    {[i[1] for i in self.helpvar_stmt if i[0] == depth]}
+    {[i[1] for i in self.helpervar_stmt if i[0] == depth]}
     {array_type} result{depth_f}({self.n_iter[depth]});
     for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[depth]}; i{depth_f}++){{
         {next_level}

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -253,9 +253,9 @@ class RDataFrame_Visit:
             new_arr_size = f"{arr_name}.size()"
             qualifiers.append("_weighted")
             time_arr=self.visit(keywords["time"])
-            if scalar_type(unpackScalarType(scalar_type_str(time_arr["type"])))[0] == 'o':
+            if scalar_type(unpackScalarType(scalar_type_str(time_arr["type"]), 1))[0] == 'o':
                 raise TypeError("Weights array for rolling sum must be of numeric data type")
-            time_arr_name = f", time_arr['implementation']"
+            time_arr_name = f", {time_arr['implementation']}.begin()"
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -231,7 +231,7 @@ class RDataFrame_Visit:
     def visit_Rolling(self, node: ast.Call):
         if len(node.args) < 2:
             raise TypeError(f"Got {len(node.args)} arguments, expected 2")
-        self.headers["RollingSum"] = "#include \"RootInteractive/Tools/RDataFrame/RollingSum.cpp\"\n"
+        self.headers["RollingSum"] = "#include \"RollingSum.cpp\""
         arr = self.visit(node.args[0])
         arr_name = arr["implementation"]
         dtype = unpackScalarType(scalar_type_str(arr["type"]), 1)
@@ -714,6 +714,8 @@ def makeDefineRNode(columnName, funName, parsed,  rdf, verbose=1, flag=0x1):
 
     try:
         ROOT.gSystem.AddIncludePath(" -I$RootInteractive/RootInteractive/Tools/RDataFrame/")
+        for i in parsed["headers"].values():
+            ROOT.gInterpreter.ProcessLine(i)
         #ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
         ROOT.gInterpreter.Declare( parsed["implementation"])
     except:

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -246,7 +246,7 @@ class RDataFrame_Visit:
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
-ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
+ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width});
 RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -247,7 +247,7 @@ class RDataFrame_Visit:
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
 RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
-RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {n_elems}, {init});
+RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":
             self.helpvar_stmt.append((0, f"""

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -713,7 +713,7 @@ def makeDefineRNode(columnName, funName, parsed,  rdf, verbose=1, flag=0x1):
     # 0.) Define function if does not exist yet
 
     try:
-        ROOT.gSystem.AddIncludePath(" -I$RootInteractive/")
+        ROOT.gSystem.AddIncludePath(" -I$RootInteractive/RootInteractive/Tools/RDataFrame/")
         #ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
         ROOT.gInterpreter.Declare( parsed["implementation"])
     except:

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -231,7 +231,7 @@ class RDataFrame_Visit:
     def visit_Rolling(self, node: ast.Call):
         if len(node.args) < 2:
             raise TypeError(f"Got {len(node.args)} arguments, expected 2")
-        self.headers["RollingSum"] = "#include \"$RootInteractive/RootInteractive/Tools/RDataFrame/RollingSum.cpp\"\n"
+        self.headers["RollingSum"] = "#include \"RootInteractive/Tools/RDataFrame/RollingSum.cpp\"\n"
         arr = self.visit(node.args[0])
         arr_name = arr["implementation"]
         dtype = unpackScalarType(scalar_type_str(arr["type"]), 1)
@@ -713,6 +713,7 @@ def makeDefineRNode(columnName, funName, parsed,  rdf, verbose=1, flag=0x1):
     # 0.) Define function if does not exist yet
 
     try:
+        ROOT.gSystem.AddIncludePath("-I$RootInteractive/")
         ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
         ROOT.gInterpreter.Declare( parsed["implementation"])
     except:

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -254,7 +254,7 @@ class RDataFrame_Visit:
             qualifiers.append("_weighted")
             time_arr=self.visit(keywords["time"])
             if scalar_type(unpackScalarType(scalar_type_str(time_arr["type"])))[0] == 'o':
-                raise TypeError("Weights array for rolling sum must be of numeric data type"
+                raise TypeError("Weights array for rolling sum must be of numeric data type")
             time_arr_name = f", time_arr['implementation']"
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -285,7 +285,7 @@ for(size_t i={width}; i;--i){{
            else:
                raise TypeError(f"Expected 2 or 3 arguments, got {len(node.args)}")
         elif isinstance(node.func, ast.Name) and node.func.id in ["rollingSum", "rollingMean", "rollingStd"]:
-            return visit_Rolling(self, node)
+            return self.visit_Rolling(node)
         args = [self.visit(iArg) for iArg in node.args]
         left = self.visit_func(node.func, args)
         implementation = left['implementation'] + '('

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -248,7 +248,7 @@ RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width-1});
 rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {n_elems}, {init});
         """))
         if node.func.id == "rollingMean":
-            self.helpvar_stmt.append(f"""
+            self.helpvar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){
     arr_{new_helper_id}[i] /= i;
 };
@@ -258,7 +258,7 @@ for(size_t i={width};i<{arr_name}.size();++i){
 for(size_t i={width}; i;--i){
     *(arr_{new_helper_id}.end()-i) /= i;
 };
-            """)
+            """))
         return {
                 "implementation":f"arr_{new_helper_id}",
                 "type":('o',f"RVec<{dtype}>")

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -246,7 +246,7 @@ class RDataFrame_Visit:
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
-RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width-1});
+RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
 RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {n_elems}, {init});
         """))
         if node.func.id == "rollingMean":

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -574,7 +574,7 @@ for(size_t i={width}; i;--i){{
         array_type = f"ROOT::VecOps::RVec<{array_type}>"
         expr_f = f"result{depth_f_lower}[i{depth_f_lower}] = result{depth_f};" if depth>0 else ""
         return f"""
-    {[i[1] for i in self.helpervar_stmt if i[0] == depth]}
+    {''.join([i[1] for i in self.helpervar_stmt if i[0] == depth])}
     {array_type} result{depth_f}({self.n_iter[depth]});
     for(size_t i{depth_f}=0; i{depth_f}<{self.n_iter[depth]}; i{depth_f}++){{
         {next_level}

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -259,7 +259,7 @@ class RDataFrame_Visit:
         if "center" in keywords:
             center = "true"
         if "time" in keywords:
-            rolling_statistic = "rolling_sum"
+            rolling_statistic_name = "rolling_sum"
             new_arr_size = f"{arr_name}.size()"
             qualifiers.append("_weighted")
             time_arr=self.visit(keywords["time"])

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -270,7 +270,7 @@ class RDataFrame_Visit:
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
 ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({new_arr_size});
-RootInteractive:{rolling_statistic_name}{''.join(qualifiers)}({arr_name}.begin(), {arr_name}.end(){time_arr_name}, arr_{new_helper_id}.begin(), {width}, {init}, {center});
+RootInteractive::{rolling_statistic_name}{''.join(qualifiers)}({arr_name}.begin(), {arr_name}.end(){time_arr_name}, arr_{new_helper_id}.begin(), {width}, {init}, {center});
         """))
         if node.func.id == "rollingMean":
             if "time" in keywords:

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -269,7 +269,8 @@ for(size_t i=0; i<{arr_name}.size(); ++i){{
     arr_{new_helper_id}[i] /= 2*{width};
 }}
                 """)
-            self.helpervar_stmt.append((0, f"""
+            else:
+                self.helpervar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){{
     arr_{new_helper_id}[i] /= i+1;
 }};

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -713,7 +713,7 @@ def makeDefineRNode(columnName, funName, parsed,  rdf, verbose=1, flag=0x1):
     # 0.) Define function if does not exist yet
 
     try:
-        ROOT.gSystem.AddIncludePath("-I$RootInteractive/")
+        ROOT.gSystem.AddIncludePath("-l$RootInteractive/")
         ROOT.gInterpreter.Declare( "".join(parsed["headers"].values()))
         ROOT.gInterpreter.Declare( parsed["implementation"])
     except:

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -246,7 +246,7 @@ class RDataFrame_Visit:
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
-ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width});
+ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width} - 1);
 RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -252,13 +252,13 @@ RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_help
         if node.func.id == "rollingMean":
             self.helpervar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){{
-    arr_{new_helper_id}[i] /= i;
+    arr_{new_helper_id}[i] /= i+1;
 }};
 for(size_t i={width};i<{arr_name}.size();++i){{
     arr_{new_helper_id}[i] /= {width};
 }};
 for(size_t i={width}; i;--i){{
-    *(arr_{new_helper_id}.end()-i) /= i;
+    *(arr_{new_helper_id}.end()-i) /= i+1;
 }};
             """))
         return {

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -229,7 +229,7 @@ class RDataFrame_Visit:
     def visit_Rolling(self, node: ast.Call):
         if len(node.args) < 2:
             raise TypeError(f"Got {len(node.args)} arguments, expected 2")
-        self.headers["RollingSum"] = "#include \"rolling_sum.cpp\"\n"
+        self.headers["RollingSum"] = "#include \"RollingSum.cpp\"\n"
         arr = self.visit(node.args[0])
         arr_name = arr["implementation"]
         dtype = unpackScalarType(scalar_type_str(arr["type"]), 1)
@@ -246,7 +246,7 @@ class RDataFrame_Visit:
         new_helper_id = self.helpervar_idx
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
-RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
+ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width}-1);
 RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":
@@ -263,7 +263,7 @@ for(size_t i={width}; i;--i){{
             """))
         return {
                 "implementation":f"arr_{new_helper_id}",
-                "type":('o',f"RVec<{dtype}>")
+                "type":('o',f"ROOT::VecOps::RVec<{dtype}>")
                 }
 
     def visit_Call(self, node: ast.Call):

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -249,15 +249,15 @@ rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {
         """))
         if node.func.id == "rollingMean":
             self.helpvar_stmt.append((0, f"""
-for(size_t i=0; i<{width};++i){
+for(size_t i=0; i<{width};++i){{
     arr_{new_helper_id}[i] /= i;
-};
-for(size_t i={width};i<{arr_name}.size();++i){
+}};
+for(size_t i={width};i<{arr_name}.size();++i){{
     arr_{new_helper_id}[i] /= {width};
-};
-for(size_t i={width}; i;--i){
+}};
+for(size_t i={width}; i;--i){{
     *(arr_{new_helper_id}.end()-i) /= i;
-};
+}};
             """))
         return {
                 "implementation":f"arr_{new_helper_id}",

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -245,7 +245,7 @@ class RDataFrame_Visit:
         self.helpervar_idx += 1
         self.helpervar_stmt.append((0, f"""
 RVec<{dtype}> arr_{new_helper_id}({arr_name}.size() + {width-1});
-rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {n_elems}, {init});
+RootInteractive::rolling_sum({arr_name}.begin(), {arr_name}.end(), arr_{new_helper_id}.begin(), {n_elems}, {init});
         """))
         if node.func.id == "rollingMean":
             self.helpvar_stmt.append((0, f"""

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -561,7 +561,8 @@ for(size_t i={width}; i;--i){{
 }} """,
 "type": array_type,
 "name": self.name,
-"dependencies": [i[0] for i in dependencies_list]
+"dependencies": [i[0] for i in dependencies_list],
+"headers": self.headers
         }
 
     def makeOuterLoop(self, depth:int, innerLoop:str, dtype:str):
@@ -732,6 +733,7 @@ def makeDefine(name, code, df, cppLibDictionary=None, verbose=3, flag=0x1):
     if verbose & 0x8:
         logging.info("makeDefine - evaluator",evaluator)
     parsed = evaluator.visit(t)
+
     if verbose>0:
         logging.info(f"{name} \n{code}")
 

--- a/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/RDataFrame_Array.py
@@ -263,6 +263,12 @@ ROOT::VecOps::RVec<{dtype}> arr_{new_helper_id}({new_arr_size});
 RootInteractive::rolling_sum{''.join(qualifiers)}({arr_name}.begin(), {arr_name}.end(){time_arr_name}, arr_{new_helper_id}.begin(), {width}, {init});
         """))
         if node.func.id == "rollingMean":
+            if "time" in keywords:
+                self.helpervar_stmt.append((0, f"""
+for(size_t i=0; i<{arr_name}.size(); ++i){{
+    arr_{new_helper_id}[i] /= 2*{width};
+}}
+                """)
             self.helpervar_stmt.append((0, f"""
 for(size_t i=0; i<{width};++i){{
     arr_{new_helper_id}[i] /= i+1;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -51,7 +51,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radiu
   unsigned long n_skip = radius >> 1;
   for(;window_end < last && window_end < first + radius; ++window_end){
 	  init = std::move(init) + *window_end;
-	  if(count >= n_skip || !center){
+	  if(count > n_skip || !center){
 	  	*d_first = init;
 	  	++d_first;
 	  }
@@ -84,7 +84,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
   for(;window_end < last && window_end < first + radius; ++window_end){
 	  ++count;
 	  init = std::move(init) + *window_end;
-	  if(count >= n_skip || !center){
+	  if(count > n_skip || !center){
 	  	*d_first = init / count;
 	  	++d_first;
 	  }

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -145,7 +145,7 @@ OutputIt rolling_std(InputIt first, InputIt last, OutputIt d_first, size_t radiu
 	  cur = *window_end;
 	  init = std::move(init) - cur;
 	  sum_sq = std::move(sum_sq) - cur*cur;
-	  ++first
+	  ++first;
 	  *d_first = (sum_sq-init*init/count)/count;
 	  ++d_first;
   }

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -114,6 +114,7 @@ OutputIt rolling_variance(InputIt first, InputIt last, OutputIt d_first, size_t 
   T sum_sq = init;
   T cur;
   for(;window_end < last && window_end < first + radius; ++window_end){
+	  ++count;
 	  cur = *window_end;
 	  init = std::move(init) + cur;
 	  sum_sq = std::move(sum_sq) + cur*cur;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -1,0 +1,37 @@
+#include <vector>
+
+using size_t = decltype(sizeof 1);
+
+template <class InputIt, class T>
+std::vector<T> rolling_sum(InputIt first, InputIt last, size_t radius, T init){
+	std::vector<T> result(last-first);
+	InputIt window_end = first;
+
+	return result;
+}
+
+  //size_t arr_size = radius < last - first ? last-first+radius : 2*(last-first)-1;
+  //std::vector<T> result(arr_size);
+template <class InputIt, class OutputIt, class T, class AddOp, class SubOp>
+void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init, AddOp add, SubOp sub){
+  InputIt window_end = first;
+  for(;window_end < last && window_end < first + radius; ++window_end){
+	  init = add(std::move(init), *window_end);
+	  *d_first = init;
+	  ++d_first;
+  }
+  while(window_end < last){
+	  init = add(std::move(init), *window_end);
+	  init = sub(std::move(init), *first);
+	  ++first;
+	  ++window_end;
+	  *d_first = init;
+	  ++d_first;
+  }
+  for(;first < last; ++first){
+	  init = sub(std::move(init), *first);
+	  *d_first = init;
+	  ++d_first;
+  }
+}
+

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -1,5 +1,8 @@
 #include <vector>
 
+#ifndef ROOTINTERACTIVE_ROLLING_SUM
+#define ROOTINTERACTIVE_ROLLING_SUM
+
 using size_t = decltype(sizeof 1);
 
 template <class InputIt, class T>
@@ -12,10 +15,13 @@ std::vector<T> rolling_sum(InputIt first, InputIt last, size_t radius, T init){
 
   //size_t arr_size = radius < last - first ? last-first+radius : 2*(last-first)-1;
   //std::vector<T> result(arr_size);
+  //
+  //TODO: Find out if it's automatically parallelized - should be, as it should find the "scan" operation
+  //Algorithm works single threaded if operation is associative and has a left inverse, but parallel only works if op is also commutative and has an inverse
 template <class InputIt, class OutputIt, class T, class AddOp, class SubOp>
-void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init, AddOp add, SubOp sub){
+void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t kernel_width, T init, AddOp add, SubOp sub){
   InputIt window_end = first;
-  for(;window_end < last && window_end < first + radius; ++window_end){
+  for(;window_end < last && window_end < first + kernel_width; ++window_end){
 	  init = add(std::move(init), *window_end);
 	  *d_first = init;
 	  ++d_first;
@@ -35,3 +41,27 @@ void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T
   }
 }
 
+template <class InputIt, class OutputIt, class T>
+void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init){
+  InputIt window_end = first;
+  for(;window_end < last && window_end < first + radius; ++window_end){
+	  init = std::move(init) + *window_end;
+	  *d_first = init;
+	  ++d_first;
+  }
+  while(window_end < last){
+	  init = std::move(init) + *window_end;
+	  init = std::move(init) - *first;
+	  ++first;
+	  ++window_end;
+	  *d_first = init;
+	  ++d_first;
+  }
+  for(;first < last; ++first){
+	  init = std::move(init) - *first;
+	  *d_first = init;
+	  ++d_first;
+  }
+}
+
+#endif

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -81,12 +81,12 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
   unsigned long count = 0;
   unsigned long n_skip = radius >> 1;
   for(;window_end < last && window_end < first + radius; ++window_end){
+	  ++count
 	  init = std::move(init) + *window_end;
 	  if(count >= n_skip || !center){
 	  	*d_first = init / count;
 	  	++d_first;
 	  }
-	  ++count;
   }
   while(window_end < last){
 	  init = std::move(init) + *window_end;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -81,7 +81,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
   unsigned long count = 0;
   unsigned long n_skip = radius >> 1;
   for(;window_end < last && window_end < first + radius; ++window_end){
-	  ++count
+	  ++count;
 	  init = std::move(init) + *window_end;
 	  if(count >= n_skip || !center){
 	  	*d_first = init / count;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -66,7 +66,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radiu
 	  ++d_first;
   }
   if(center){
-  	for(;count>0; --count){
+  	for(;count>n_skip; --count){
 		  init = std::move(init) - *first;
 		  ++first;
 		  *d_first = init;
@@ -98,7 +98,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
 	  ++d_first;
   }
   if(center){
-  for(;count>0; --count){
+  for(;count>n_skip; --count){
 	  init = std::move(init) - *first;
 	  ++first;
 	  *d_first = init / count;
@@ -120,8 +120,10 @@ OutputIt rolling_variance(InputIt first, InputIt last, OutputIt d_first, size_t 
 	  cur = *window_end;
 	  init = std::move(init) + cur;
 	  sum_sq = std::move(sum_sq) + cur*cur;
-	  *d_first = (sum_sq-init*init/count)/count;
-	  ++d_first;
+	  if(count > n_skip || !center){
+	  	*d_first = (sum_sq-init*init/count)/count;
+	  	++d_first;
+	  }
   }
   while(window_end < last){
 	  cur = *window_end;
@@ -135,12 +137,15 @@ OutputIt rolling_variance(InputIt first, InputIt last, OutputIt d_first, size_t 
 	  *d_first = (sum_sq-init*init/count)/count;
 	  ++d_first;
   }
-  for(;count>0; --count){
+  if(center){
+  for(;count>n_skip; --count){
 	  cur = *window_end;
 	  init = std::move(init) - cur;
 	  sum_sq = std::move(sum_sq) - cur*cur;
+	  ++first
 	  *d_first = (sum_sq-init*init/count)/count;
 	  ++d_first;
+  }
   }
   return d_first;
 }

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -111,7 +111,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
 }
 
 template <class InputIt, class OutputIt, class T>
-OutputIt rolling_variance(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init, bool center){
+OutputIt rolling_std(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init, bool center){
   InputIt window_end = first;
   unsigned long count = 0;
   unsigned long n_skip = radius >> 1;
@@ -171,7 +171,7 @@ OutputIt rolling_sum_symmetric(InputIt first, InputIt last, OutputIt d_first, si
 }
 
 template <class InputIt, class WeightsIt, class OutputIt, class T, class DistT>
-OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, OutputIt d_first, DistT width, T init, bool center){
+OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, OutputIt d_first, DistT radius, T init, bool center){
 	// Uses rolling window and nearest neighbor interpolation
 	InputIt low = first;
 	InputIt high = first;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -44,7 +44,7 @@ void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t kernel_wi
 }
 
 template <class InputIt, class OutputIt, class T>
-void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init){
+OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T init){
   InputIt window_end = first;
   for(;window_end < last && window_end < first + radius; ++window_end){
 	  init = std::move(init) + *window_end;
@@ -59,13 +59,28 @@ void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T
 	  *d_first = init;
 	  ++d_first;
   }
-  for(;first < last; ++first){
+  for(;first+1 < last; ++first){
 	  init = std::move(init) - *first;
 	  *d_first = init;
 	  ++d_first;
   }
+  return d_first
 }
 
+template <class InputIt, class OutputIt, class T>
+OutputIt rolling_sum_symmetric(InputIt first, InputIt last, OutputIt d_first, size_t width, T init)
+	// compute the cumulative sum of difference
+	OutputIt d_last = d_first;
+	InputIt high = first+width;
+	InputIt low = first;
+	while(low<last){
+		*d_last = *high - *low; 
+		++d_last;
+		++high;
+		high = high == last ? first : high;
+		++low;
+	}	
+	return std::exclusive_scan(d_first, d_last, d_first, std::reduce(first, first+width)+init);
 }
 
 #endif

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -41,7 +41,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t kerne
 	  *d_first = init;
 	  ++d_first;
   }
-  return d_first
+  return d_first;
 }
 
 template <class InputIt, class OutputIt, class T>
@@ -65,7 +65,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radiu
 	  *d_first = init;
 	  ++d_first;
   }
-  return d_first
+  return d_first;
 }
 
 template <class InputIt, class OutputIt, class T>
@@ -107,6 +107,7 @@ OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, Ou
 		++w_first;
 	}
 	return d_first;
+}
 }
 
 #endif

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -66,6 +66,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radiu
 	  ++d_first;
   }
   if(center){
+	  --count;
   	for(;count>n_skip; --count){
 		  init = std::move(init) - *first;
 		  ++first;
@@ -98,6 +99,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
 	  ++d_first;
   }
   if(center){
+	  --count;
   for(;count>n_skip; --count){
 	  init = std::move(init) - *first;
 	  ++first;
@@ -138,6 +140,7 @@ OutputIt rolling_variance(InputIt first, InputIt last, OutputIt d_first, size_t 
 	  ++d_first;
   }
   if(center){
+	  --count;
   for(;count>n_skip; --count){
 	  cur = *window_end;
 	  init = std::move(init) - cur;
@@ -168,19 +171,20 @@ OutputIt rolling_sum_symmetric(InputIt first, InputIt last, OutputIt d_first, si
 }
 
 template <class InputIt, class WeightsIt, class OutputIt, class T, class DistT>
-OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, OutputIt d_first, DistT radius, T init){
+OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, OutputIt d_first, DistT width, T init, bool center){
 	// Uses rolling window and nearest neighbor interpolation
 	InputIt low = first;
 	InputIt high = first;
 	WeightsIt w_low = w_first;
 	WeightsIt w_high = w_first;
+	DistT off_low = center ? -radius : 0;
 	for(;first<last;++first){
 		while(high < last && *w_first + radius > *w_high){
 			init = std::move(init) + *high;
 			++high;
 			++w_high;
 		}
-		while(*w_first - radius > *w_low){
+		while(*w_first + off_low > *w_low){
 			init = std::move(init) - *low;
 			++low;
 			++w_low;

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -68,6 +68,7 @@ OutputIt rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radiu
   if(center){
   	for(;count>0; --count){
 		  init = std::move(init) - *first;
+		  ++first;
 		  *d_first = init;
 		  ++d_first;
  	 }
@@ -99,6 +100,7 @@ OutputIt rolling_mean(InputIt first, InputIt last, OutputIt d_first, size_t radi
   if(center){
   for(;count>0; --count){
 	  init = std::move(init) - *first;
+	  ++first;
 	  *d_first = init / count;
 	  ++d_first;
   }

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -5,6 +5,8 @@
 
 using size_t = decltype(sizeof 1);
 
+namespace RootInteractive {
+
 template <class InputIt, class T>
 std::vector<T> rolling_sum(InputIt first, InputIt last, size_t radius, T init){
 	std::vector<T> result(last-first);
@@ -62,6 +64,8 @@ void rolling_sum(InputIt first, InputIt last, OutputIt d_first, size_t radius, T
 	  *d_first = init;
 	  ++d_first;
   }
+}
+
 }
 
 #endif

--- a/RootInteractive/Tools/RDataFrame/RollingSum.cpp
+++ b/RootInteractive/Tools/RDataFrame/RollingSum.cpp
@@ -87,6 +87,7 @@ OutputIt rolling_sum_symmetric(InputIt first, InputIt last, OutputIt d_first, si
 
 template <class InputIt, class WeightsIt, class OutputIt, class T, class DistT>
 OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, OutputIt d_first, DistT radius, T init){
+	// Uses rolling window and nearest neighbor interpolation
 	InputIt low = first;
 	InputIt high = first;
 	WeightsIt w_low = w_first;
@@ -108,6 +109,7 @@ OutputIt rolling_sum_weighted(InputIt first, InputIt last, WeightsIt w_first, Ou
 	}
 	return d_first;
 }
+
 }
 
 #endif

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,7 +223,7 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D0", "rollingSum(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -227,10 +227,12 @@ def test_define2(rdf):
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 5, 0, center=True)[4:]-array1D0[2:-2])", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 5, 0, center=True)[2:-2]-array1D0[2:-2])", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D1").GetValue())
     rdf = makeDefine("arrayRollingMean1D2", "abs(rollingMean(array1D0, 2.5, time=array1D0)[2:-2]-array1D0[2:-2])", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D2").GetValue())
+    rdf = makeDefine("arrayRollingStd1D0", "abs(rollingStd(array1D0, 5)[2:-2]-10)", rdf, None, 3)
+    print(rdf.Sum("arrayRollingStd1D0").GetValue())
     return rdf
 
 def test_exception(rdf):

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,12 +223,14 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 5, 0)[4:-4]/array1D0[2:-2]-1", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 5, 0)[4:]/array1D0[2:-2]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[2:-2]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 2.5, time=array1D0)[2:-2]-array1D0[2:-2])", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 5, 0, center=True)[4:]-array1D0[2:-2])", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D1").GetValue())
+    rdf = makeDefine("arrayRollingMean1D2", "abs(rollingMean(array1D0, 2.5, time=array1D0)[2:-2]-array1D0[2:-2])", rdf, None, 3)
+    print(rdf.Sum("arrayRollingMean1D2").GetValue())
     return rdf
 
 def test_exception(rdf):

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,9 +223,9 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/5-array1D0[2:-2]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/5-array1D0[1:-2]", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,9 +223,9 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/array1D0[:]-1", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-4]/array1D0[2:-2]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-5]-array1D0[:]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,6 +223,8 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
+    print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 
 def test_exception(rdf):

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -227,6 +227,8 @@ def test_define2(rdf):
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
+    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 2.5, time=array1D0)[:]-array1D0[:])", rdf, None, 3)
+    print(rdf.Sum("arrayRollingMean1D1").GetValue())
     return rdf
 
 def test_exception(rdf):

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,7 +223,7 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-4]/array1D0[2:-2]-1", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 5, 0)[4:-4]/array1D0[2:-2]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -227,7 +227,7 @@ def test_define2(rdf):
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 2.5, time=array1D0)[:]-array1D0[:])", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D1", "abs(rollingMean(array1D0, 2.5, time=array1D0)[2:-2]-array1D0[2:-2])", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D1").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -231,7 +231,7 @@ def test_define2(rdf):
     print(rdf.Sum("arrayRollingMean1D1").GetValue())
     rdf = makeDefine("arrayRollingMean1D2", "abs(rollingMean(array1D0, 2.5, time=array1D0)[2:-2]-array1D0[2:-2])", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D2").GetValue())
-    rdf = makeDefine("arrayRollingStd1D0", "abs(rollingStd(array1D0, 5)[2:-2]-10)", rdf, None, 3)
+    rdf = makeDefine("arrayRollingStd1D0", "abs(rollingStd(array1D0, 5)[2:-2]-2)", rdf, None, 3)
     print(rdf.Sum("arrayRollingStd1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,7 +223,9 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingMean1D0", "rollingSum(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]-5", rdf, None, 3)
+    print(rdf.Sum("arrayRollingSum1D0").GetValue())
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -225,7 +225,7 @@ def test_define2(rdf):
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
     rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-4]/array1D0[2:-2]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
-    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[:]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-4]-array1D0[2:-2]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf
 

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,8 +223,8 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]-5", rdf, None, 3)
-    print(rdf.Sum("arrayRollingSum1D0").GetValue())
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/5-array1D0[2:-2]", rdf, None, 3)
+    print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())
     return rdf

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,7 +223,7 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/array1D0[2:-2]-1", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/array1D0[:]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())

--- a/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
+++ b/RootInteractive/Tools/RDataFrame/test_RDataFrame_Array.py
@@ -223,7 +223,7 @@ def test_define2(rdf):
     rdf = makeDefine("inv_arrayJoin_upper", "arrayJoin_1[:] < nPoints2 and array1DTPCTrack2[arrayJoin_1[:]].getZ() <= array1DTPCTrack[:].getZ()", rdf, None, 3)
     assert rdf.Sum("inv_arrayJoin").GetValue() == 0
     assert rdf.Sum("inv_arrayJoin_upper").GetValue() == 0
-    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/5-array1D0[1:-2]", rdf, None, 3)
+    rdf = makeDefine("arrayRollingSum1D0", "rollingSum(array1D0, 4, 0)[4:-5]/array1D0[2:-2]-1", rdf, None, 3)
     print(rdf.Mean("arrayRollingSum1D0").GetValue())
     rdf = makeDefine("arrayRollingMean1D0", "rollingMean(array1D0, 5, 0)[4:-5]-array1D0[:]", rdf, None, 3)
     print(rdf.Sum("arrayRollingMean1D0").GetValue())


### PR DESCRIPTION
This PR adds support for rolling window statistics in the RDataFrame interface 

To do: Add rolling median, fix inconsistent window width input parameter for time series index, add rolling variance support for time series index

Example in test_RDataFrame_Array.py