### PR TITLE
Bugfix for caching functions on the client used multiple times (introduced in #336, mentioned in #340)

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -192,7 +192,7 @@ export class CDSAlias extends ColumnarDataSource {
   invalidate_columns(keys: string[], emit_change=true){
     let watched_changed = false
     for(const key of keys){
-      const did_change = this.invalidae_column(key, false)
+      const did_change = this.invalidate_column(key, false)
       watched_changed = watched_changed || did_change
     }
     if(watched_changed && emit_change){

--- a/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/CDSAlias.ts
@@ -192,7 +192,8 @@ export class CDSAlias extends ColumnarDataSource {
   invalidate_columns(keys: string[], emit_change=true){
     let watched_changed = false
     for(const key of keys){
-      watched_changed ||= this.invalidate_column(key, false)
+      const did_change = this.invalidae_column(key, false)
+      watched_changed = watched_changed || did_change
     }
     if(watched_changed && emit_change){
       console.log(keys)

--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdCDS.ts
@@ -521,7 +521,7 @@ export class HistoNdCDS extends ColumnarDataSource {
     for(let i=0; i<working_indices.length; i++){
       working_indices[i] -= histogram[i]
     }
-    const view_sorted: number[] = Array(n_entries)
+    const view_sorted: number[] = Array(n_entries).fill(0)
     const l = view != null ? view.length : source.get_length()!
     if(view == null){
       for(let i=0; i<l; i++){


### PR DESCRIPTION
This PR fixes a bug introduced in #336 causing changing the diff function to not invalidate the cached values if the diff function is used in multiple places. This bug was already caught by a test, test_bokehClientHistogram.py::test_interactiveTemplateMultiYDiff 

This PR also optimizes computing projections from histograms by preventing a sparse array from being created.