### PR TITLE
Removed uproot dependency

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/bokehTools.py
@@ -9,7 +9,7 @@ from bokeh.models.plots import Plot
 from bokeh.transform import *
 from RootInteractive.InteractiveDrawing.bokeh.ConcatenatedString import ConcatenatedString
 from RootInteractive.InteractiveDrawing.bokeh.compileVarName import getOrMakeColumns
-from RootInteractive.Tools.aliTreePlayer import *
+from RootInteractive.Tools.pandaTools import initMetadata
 from bokeh.layouts import *
 import logging
 from IPython import get_ipython

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehClientHistogram.py
@@ -1,5 +1,4 @@
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
-from RootInteractive.Tools.aliTreePlayer import *
 from RootInteractive.InteractiveDrawing.bokeh.bokehTools import mergeFigureArrays
 from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveTemplate import getDefaultVarsDiff, getDefaultVarsRatio, getDefaultVarsNormAll
 from RootInteractive.InteractiveDrawing.bokeh.bokehInteractiveParameters import figureParameters

--- a/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
+++ b/RootInteractive/InteractiveDrawing/bokeh/test_bokehDrawSA.py
@@ -1,5 +1,4 @@
 from RootInteractive.InteractiveDrawing.bokeh.bokehDrawSA import *
-from RootInteractive.Tools.aliTreePlayer import *
 from bokeh.io import curdoc
 import os
 import sys
@@ -11,6 +10,7 @@ import math
 
 if "ROOT" in sys.modules:
     from ROOT import TFile, gSystem
+    from RootInteractive.Tools.aliTreePlayer import *
 
 output_file("test_bokehDrawSA.html")
 # import logging


### PR DESCRIPTION
This PR removes uproot dependency from bokehDrawSA.py - it was caused by a star import that didn't have to be there