### PR TITLE
HistoNdProfile data dependency leak fix

### DIFF
--- a/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
+++ b/RootInteractive/InteractiveDrawing/bokeh/HistoNdProfile.ts
@@ -70,7 +70,6 @@ export class HistoNdProfile extends ColumnarDataSource {
         const isOK_column = []
         const cumulative_column: number[] = []
         const cdf_column = []
-        const weights_column = []
         let quantile_columns:Array<Array<number>> = []
         for (let i = 0; i < quantiles.length; i++) {
           quantile_columns.push([])
@@ -302,7 +301,6 @@ export class HistoNdProfile extends ColumnarDataSource {
                 integral_columns[iBox].push(integral)
                 efficiency_columns[iBox].push(integral/entries)
               }
-              weights_column.push(current_weights ?? "None")
             }
           }
           for(let i=offset; i<cumulative_column.length; ++i){
@@ -333,7 +331,6 @@ export class HistoNdProfile extends ColumnarDataSource {
               this.data["bin_top_"+i] = bin_top_filtered[i]
           }
         }
-        this.data["weights"] = weights_column
         this._stale = false
         if(sorted_entries != null){
           source.return_column_to_pool(sorted_entries)
@@ -341,10 +338,23 @@ export class HistoNdProfile extends ColumnarDataSource {
   }
 
   get_column(key: string){
+    if(key == "weights"){
+      return this.get_weights_label()
+    }
     if(this._stale){
       this.update()
     }
     return this.data[key]
+  }
+
+  get_weights_label(){
+    const l = this.source.get_length() / this.source.nbins[this.axis_idx]
+    if(Array.isArray(this.weights)){
+      return this.weights.flatMap((w: string | null) => Array(l).fill(w ?? "None"))
+    } else if(this.weights != null){
+      return Array(l).fill(this.weights)
+    }
+    return Array(l).fill("None")
   }
 
   get_length(){


### PR DESCRIPTION
This PR:
- Probably fixes a bug with uninitialized bin caching in ND histograms, not 100% sure as I can't reproduce it reliably, it's also a hacky workaround and a more permanent fix will follow soon
- Fixes a bug with HistoNdProfile leaking a compute heavy data dependency in case of multiple weights, optimizing by a factor that scales with the number of histograms, but usually 2x-3x
- Optimizes histogram auto ranges by removing Math.min() and Math.max(), forgot to check time before change
- Changes iteration order in ND histogram from row major to column major, this change improves the performance of the histogram by 30%